### PR TITLE
[TASK] Provide UpgradeWizard to migrate glossaries to new tables

### DIFF
--- a/Build/php-cs-fixer/php-cs-rules.php
+++ b/Build/php-cs-fixer/php-cs-rules.php
@@ -48,7 +48,7 @@ return (new PhpCsFixer\Config())
         'no_blank_lines_after_phpdoc' => true,
         'array_syntax' => ['syntax' => 'short'],
         'whitespace_after_comma_in_array' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'no_alias_functions' => true,
         'lowercase_cast' => true,
         'no_leading_namespace_whitespace' => true,
@@ -70,14 +70,16 @@ return (new PhpCsFixer\Config())
         'declare_equal_normalize' => ['space' => 'none'],
         'dir_constant' => true,
         'phpdoc_no_access' => true,
-        'compact_nullable_typehint' => true,
+        'compact_nullable_type_declaration' => true,
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'modernize_types_casting' => true,
-        'new_with_braces' => true,
+        'new_with_parentheses' => true,
         'no_empty_phpdoc' => true,
         'no_null_property_initialization' => true,
         'php_unit_mock_short_will_return' => true,
-        'php_unit_test_case_static_method_calls' => ['call_type' => 'static'],
+        // @todo validate, how to handle self:: to static:: mappings, as this makes no sense for
+        //       final classes
+        //'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
         'single_trait_insert_per_statement' => true,
     ])
     ->setFinder($finder);

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -84,3 +84,13 @@ parameters:
 			message: "#^Parameter \\#3 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry given\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/ext_emconf.php
+
+		-
+			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/ext_emconf.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,2 +1,101 @@
 parameters:
 	ignoreErrors:
+		-
+			message: "#^Parameter \\#3 \\$severity of class TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage constructor expects TYPO3\\\\CMS\\\\Core\\\\Type\\\\ContextualFeedbackSeverity, int given\\.$#"
+			count: 1
+			path: ../../../Classes/Controller/GlossarySyncController.php
+
+		-
+			message: "#^Method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Connection\\:\\:lastInsertId\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\RequestInterface\\:\\:getQueryParams\\(\\)\\.$#"
+			count: 1
+			path: ../../../Classes/EventListener/GlossaryModuleShouldNotRenderDeepLTranslationDropdown.php
+
+		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/AbstractDeepLTestCase.php
+
+		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration\\:\\:write\\(\\)\\.$#"
+			count: 2
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 7 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Class WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Fixtures\\\\Frontend\\\\PhpError not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildErrorHandlingConfiguration\\(\\) has parameter \\$codes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildErrorHandlingConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildLanguageConfiguration\\(\\) has parameter \\$fallbackIdentifiers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:failIfArrayIsNotEmpty\\(\\) has parameter \\$items with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:mergeSiteConfiguration\\(\\) has parameter \\$overrides with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$errorHandling with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Glossary\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$siteSettingsFactory of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/ext_emconf.php
+
+		-
+			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/ext_emconf.php

--- a/Tests/Functional/Regression/GlossaryRegressionTest.php
+++ b/Tests/Functional/Regression/GlossaryRegressionTest.php
@@ -93,7 +93,7 @@ final class GlossaryRegressionTest extends AbstractDeepLTestCase
         $dataHandler->start([], $commandMap);
         $dataHandler->process_cmdmap();
 
-        static::assertEmpty($dataHandler->errorLog);
+        self::assertEmpty($dataHandler->errorLog);
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/translateWithGlossary.csv');
     }
 }

--- a/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/composer.json
+++ b/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/composer.json
@@ -1,0 +1,16 @@
+{
+	"name": "web-vision/test-migration",
+	"type": "typo3-cms-extension",
+	"description": "Add table definitions for migration tests.",
+	"license": ["GPL-2.0-or-later"],
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "test_migration"
+		}
+	},
+	"require": {
+		"typo3/cms-core": "*",
+		"web-vision/deepltranslate-core": "*",
+		"web-vision/deepltranslate-glossary": "*"
+	}
+}

--- a/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/ext_emconf.php
+++ b/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/ext_emconf.php
@@ -23,6 +23,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
             'deepltranslate_core' => '*',
+            'deepltranslate_glossary' => '*',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/ext_tables.sql
+++ b/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration/ext_tables.sql
@@ -1,0 +1,30 @@
+create table tx_wvdeepltranslate_glossary
+(
+	uid               int unsigned auto_increment primary key,
+	pid               int unsigned      default 0  not null,
+	tstamp            int unsigned      default 0  not null,
+	crdate            int unsigned      default 0  not null,
+	deleted           smallint unsigned default 0  not null,
+	glossary_ready    int unsigned      default 0  null,
+	glossary_lastsync int unsigned      default 0  not null,
+	glossary_id       varchar(60)       default '' null,
+	glossary_name     varchar(255)      default '' not null,
+	source_lang       varchar(10)       default '' not null,
+	target_lang       varchar(10)       default '' not null
+);
+
+create table tx_wvdeepltranslate_glossaryentry
+(
+	uid              int unsigned auto_increment primary key,
+	pid              int unsigned      default 0  not null,
+	tstamp           int unsigned      default 0  not null,
+	crdate           int unsigned      default 0  not null,
+	deleted          smallint unsigned default 0  not null,
+	hidden           smallint unsigned default 0  not null,
+	sys_language_uid int               default 0  not null,
+	l10n_parent      int unsigned      default 0  not null,
+	l10n_source      int unsigned      default 0  not null,
+	l10n_state       text                         null,
+	l10n_diffsource  mediumblob                   null,
+	term             varchar(255)      default '' null
+);

--- a/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/composer.json
+++ b/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/composer.json
@@ -1,0 +1,16 @@
+{
+	"name": "web-vision/test-migration-deleted",
+	"type": "typo3-cms-extension",
+	"description": "Add table definitions for migration tests.",
+	"license": ["GPL-2.0-or-later"],
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "test_migration_deleted"
+		}
+	},
+	"require": {
+		"typo3/cms-core": "*",
+		"web-vision/deepltranslate-core": "*",
+		"web-vision/deepltranslate-glossary": "*"
+	}
+}

--- a/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/ext_emconf.php
+++ b/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/ext_emconf.php
@@ -23,6 +23,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
             'deepltranslate_core' => '*',
+            'deepltranslate_glossary' => '*',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/ext_tables.sql
+++ b/Tests/Functional/Upgrade/Fixtures/Extensions/test_migration_deleted/ext_tables.sql
@@ -1,0 +1,30 @@
+create table zzz_deleted_tx_wvdeepltranslate_glossary
+(
+	uid               int unsigned auto_increment primary key,
+	pid               int unsigned      default 0  not null,
+	tstamp            int unsigned      default 0  not null,
+	crdate            int unsigned      default 0  not null,
+	deleted           smallint unsigned default 0  not null,
+	glossary_ready    int unsigned      default 0  null,
+	glossary_lastsync int unsigned      default 0  not null,
+	glossary_id       varchar(60)       default '' null,
+	glossary_name     varchar(255)      default '' not null,
+	source_lang       varchar(10)       default '' not null,
+	target_lang       varchar(10)       default '' not null
+);
+
+create table zzz_deleted_tx_wvdeepltranslate_glossaryentry
+(
+	uid              int unsigned auto_increment primary key,
+	pid              int unsigned      default 0  not null,
+	tstamp           int unsigned      default 0  not null,
+	crdate           int unsigned      default 0  not null,
+	deleted          smallint unsigned default 0  not null,
+	hidden           smallint unsigned default 0  not null,
+	sys_language_uid int               default 0  not null,
+	l10n_parent      int unsigned      default 0  not null,
+	l10n_source      int unsigned      default 0  not null,
+	l10n_state       text                         null,
+	l10n_diffsource  mediumblob                   null,
+	term             varchar(255)      default '' null
+);

--- a/Tests/Functional/Upgrade/Fixtures/Result/standardMigration.csv
+++ b/Tests/Functional/Upgrade/Fixtures/Result/standardMigration.csv
@@ -1,0 +1,19 @@
+tx_deepltranslate_glossary
+,uid,pid,tstamp,crdate,deleted,glossary_ready,glossary_lastsync,glossary_id,glossary_name,source_lang,target_lang
+,1,2,0,0,0,0,0,"",Glossary: en => de,en,de
+,2,2,0,0,0,0,0,"",Glossary: de => da,de,da
+,3,2,0,0,0,0,0,"",Glossary: en => da,en,da
+,4,2,0,0,0,0,0,"",Glossary: da => de,da,de
+tx_deepltranslate_glossaryentry
+,uid,pid,tstamp,crdate,deleted,hidden,sys_language_uid,l10n_parent,l10n_source,l10n_state,l10n_diffsource,term
+,1,2,1734598459,1734598459,0,0,0,0,0,,"",web-vision
+,2,2,1734598463,1734598463,0,0,2,1,1,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""web-vision""}",web-vision
+,3,2,1734607018,1734607018,0,0,1,1,1,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""web-vision""}",web-vision
+,4,2,1734607426,1734607426,0,0,0,0,0,,"",Rauch
+,5,2,1734607429,1734607429,0,0,1,4,4,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Rauch""}",Rauch
+,6,2,1734607432,1734607432,0,0,2,4,4,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Rauch""}",Rauch
+,7,2,1734607517,1734607517,0,0,0,0,0,,"",Smokey
+,8,2,1734607519,1734607519,0,0,1,7,7,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Smokey""}",Smokey
+,9,2,1734607521,1734607521,0,0,2,7,7,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Smokey""}",Smokey
+,10,2,1734607621,1734607621,0,0,0,0,0,,"",Love line
+,11,2,1734607623,1734607623,0,0,2,10,10,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Love line""}",Love line

--- a/Tests/Functional/Upgrade/Fixtures/migration.csv
+++ b/Tests/Functional/Upgrade/Fixtures/migration.csv
@@ -1,0 +1,24 @@
+pages
+,"uid","pid",doktype,"title",subtitle,"sys_language_uid","l10n_parent","slug","module"
+,1,0,1,"Deepl-Functional-Test","",0,0,"/",
+,2,1,254,"Glossary","",0,0,"","glossary"
+,3,1,254,"Glossar","",1,2,"",
+tx_wvdeepltranslate_glossary
+,uid,pid,tstamp,crdate,deleted,glossary_ready,glossary_lastsync,glossary_id,glossary_name,source_lang,target_lang
+,1,2,0,0,0,0,0,"",Glossary: en => de,en,de
+,2,2,0,0,0,0,0,"",Glossary: de => da,de,da
+,3,2,0,0,0,0,0,"",Glossary: en => da,en,da
+,4,2,0,0,0,0,0,"",Glossary: da => de,da,de
+tx_wvdeepltranslate_glossaryentry
+,uid,pid,tstamp,crdate,deleted,hidden,sys_language_uid,l10n_parent,l10n_source,l10n_state,l10n_diffsource,term
+,1,2,1734598459,1734598459,0,0,0,0,0,,"",web-vision
+,2,2,1734598463,1734598463,0,0,2,1,1,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""web-vision""}",web-vision
+,3,2,1734607018,1734607018,0,0,1,1,1,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""web-vision""}",web-vision
+,4,2,1734607426,1734607426,0,0,0,0,0,,"",Rauch
+,5,2,1734607429,1734607429,0,0,1,4,4,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Rauch""}",Rauch
+,6,2,1734607432,1734607432,0,0,2,4,4,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Rauch""}",Rauch
+,7,2,1734607517,1734607517,0,0,0,0,0,,"",Smokey
+,8,2,1734607519,1734607519,0,0,1,7,7,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Smokey""}",Smokey
+,9,2,1734607521,1734607521,0,0,2,7,7,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Smokey""}",Smokey
+,10,2,1734607621,1734607621,0,0,0,0,0,,"",Love line
+,11,2,1734607623,1734607623,0,0,2,10,10,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Love line""}",Love line

--- a/Tests/Functional/Upgrade/Fixtures/migrationWithDeleted.csv
+++ b/Tests/Functional/Upgrade/Fixtures/migrationWithDeleted.csv
@@ -1,0 +1,24 @@
+pages
+,"uid","pid",doktype,"title",subtitle,"sys_language_uid","l10n_parent","slug","module"
+,1,0,1,"Deepl-Functional-Test","",0,0,"/",
+,2,1,254,"Glossary","",0,0,"","glossary"
+,3,1,254,"Glossar","",1,2,"",
+zzz_deleted_tx_wvdeepltranslate_glossary
+,uid,pid,tstamp,crdate,deleted,glossary_ready,glossary_lastsync,glossary_id,glossary_name,source_lang,target_lang
+,1,2,0,0,0,0,0,"",Glossary: en => de,en,de
+,2,2,0,0,0,0,0,"",Glossary: de => da,de,da
+,3,2,0,0,0,0,0,"",Glossary: en => da,en,da
+,4,2,0,0,0,0,0,"",Glossary: da => de,da,de
+zzz_deleted_tx_wvdeepltranslate_glossaryentry
+,uid,pid,tstamp,crdate,deleted,hidden,sys_language_uid,l10n_parent,l10n_source,l10n_state,l10n_diffsource,term
+,1,2,1734598459,1734598459,0,0,0,0,0,,"",web-vision
+,2,2,1734598463,1734598463,0,0,2,1,1,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""web-vision""}",web-vision
+,3,2,1734607018,1734607018,0,0,1,1,1,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""web-vision""}",web-vision
+,4,2,1734607426,1734607426,0,0,0,0,0,,"",Rauch
+,5,2,1734607429,1734607429,0,0,1,4,4,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Rauch""}",Rauch
+,6,2,1734607432,1734607432,0,0,2,4,4,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Rauch""}",Rauch
+,7,2,1734607517,1734607517,0,0,0,0,0,,"",Smokey
+,8,2,1734607519,1734607519,0,0,1,7,7,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Smokey""}",Smokey
+,9,2,1734607521,1734607521,0,0,2,7,7,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Smokey""}",Smokey
+,10,2,1734607621,1734607621,0,0,0,0,0,,"",Love line
+,11,2,1734607623,1734607623,0,0,2,10,10,,"{""l10n_parent"":""0"",""l10n_diffsource"":"""",""hidden"":""0"",""sys_language_uid"":""0"",""l10n_source"":""0"",""term"":""Love line""}",Love line

--- a/Tests/Functional/Upgrade/MigrateDeletedTablesFromOldStructureWizardTest.php
+++ b/Tests/Functional/Upgrade/MigrateDeletedTablesFromOldStructureWizardTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Upgrade;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use WebVision\Deepltranslate\Glossary\Upgrade\MigrateTablesFromOldStructureWizard;
+
+final class MigrateDeletedTablesFromOldStructureWizardTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepltranslate-core',
+        'web-vision/deepltranslate-glossary',
+        __DIR__ . '/Fixtures/Extensions/test_migration_deleted',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-scheduler',
+        'typo3/cms-setup',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    #[Test]
+    public function deletedTableMigrationWorks(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/migrationWithDeleted.csv');
+        $subject = $this->get(MigrateTablesFromOldStructureWizard::class);
+        $necessary = $subject->updateNecessary();
+        self::assertTrue($necessary);
+        $updateDone = $subject->executeUpdate();
+        self::assertTrue($updateDone);
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Result/standardMigration.csv');
+    }
+}

--- a/Tests/Functional/Upgrade/MigrateTablesFromOldStructureWizardTest.php
+++ b/Tests/Functional/Upgrade/MigrateTablesFromOldStructureWizardTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Upgrade;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use WebVision\Deepltranslate\Glossary\Upgrade\MigrateTablesFromOldStructureWizard;
+
+final class MigrateTablesFromOldStructureWizardTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepltranslate-core',
+        'web-vision/deepltranslate-glossary',
+        __DIR__ . '/Fixtures/Extensions/test_migration',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-scheduler',
+        'typo3/cms-setup',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    #[Test]
+    public function notDeletedTableMigrationWorks(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/migration.csv');
+        $subject = $this->get(MigrateTablesFromOldStructureWizard::class);
+        $necessary = $subject->updateNecessary();
+        self::assertTrue($necessary);
+        $updateDone = $subject->executeUpdate();
+        self::assertTrue($updateDone);
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Result/standardMigration.csv');
+    }
+}

--- a/Tests/Unit/Access/AllowedGlossarySyncAccessTest.php
+++ b/Tests/Unit/Access/AllowedGlossarySyncAccessTest.php
@@ -22,30 +22,30 @@ class AllowedGlossarySyncAccessTest extends UnitTestCase
     #[Test]
     public function hasInterfaceImplementation(): void
     {
-        static::assertInstanceOf(AccessItemInterface::class, $this->accessInstance);
+        self::assertInstanceOf(AccessItemInterface::class, $this->accessInstance);
     }
 
     #[Test]
     public function getIdentifier(): void
     {
-        static::assertSame('allowedGlossarySync', $this->accessInstance->getIdentifier());
+        self::assertSame('allowedGlossarySync', $this->accessInstance->getIdentifier());
     }
 
     #[Test]
     public function getTitle(): void
     {
-        static::assertIsString($this->accessInstance->getTitle());
+        self::assertIsString($this->accessInstance->getTitle());
     }
 
     #[Test]
     public function getDescription(): void
     {
-        static::assertIsString($this->accessInstance->getDescription());
+        self::assertIsString($this->accessInstance->getDescription());
     }
 
     #[Test]
     public function getIconIdentifier(): void
     {
-        static::assertSame('deepl-logo', $this->accessInstance->getIconIdentifier());
+        self::assertSame('deepl-logo', $this->accessInstance->getIconIdentifier());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,84 +1,104 @@
 {
-  "name": "web-vision/deepltranslate-glossary",
-  "description": "This extension provides option to auto and renew translate within TYPO3 CMS",
-  "license": [
-    "GPL-2.0-or-later"
-  ],
-  "type": "typo3-cms-extension",
-  "keywords": [
-    "TYPO3 CMS",
-    "extension",
-    "translate",
-    "deepl"
-  ],
-  "authors": [
-    {
-      "name": "web-vision GmbH",
-      "email": "hello@web-vision.de",
-      "role": "Maintainer"
-    },
-    {
-      "name": "Mark Houben",
-      "email": "markhouben91@gmail.com",
-      "role": "Developer"
-    }
-  ],
-  "homepage": "https://www.web-vision.de/en/automated-translations-with-typo3-and-deepl.html",
-  "support": {
-    "issues": "https://github.com/web-vision/deepltranslate-glossary/issues",
-    "source": "https://github.com/web-vision/deepltranslate-glossary"
-  },
-  "require": {
-    "php": "^8.0",
-    "ext-curl": "*",
-    "ext-json": "*",
-    "ext-pdo": "*",
-    "typo3/cms-core": "^12.4.2 || ^13.4",
-    "web-vision/deepltranslate-core": "~5.0@dev"
-  },
-  "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.64",
-    "php-mock/php-mock-phpunit": "^2.6",
-    "phpstan/phpstan": "^1.10",
-    "phpunit/phpunit": "^10.5",
-    "ramsey/uuid": "^4.7",
-    "saschaegerer/phpstan-typo3": "^1.9",
-    "typo3/cms-belog": "^12.4.2 || ^13.4",
-    "typo3/cms-lowlevel": "^12.4.2 || ^13.4",
-    "typo3/cms-rte-ckeditor": "^12.4.2 || ^13.4",
-    "typo3/cms-setup": "^12.4.2 || ^13.4",
-    "typo3/cms-tstemplate": "^12.4.2 || ^13.4",
-    "typo3/cms-workspaces": "^12.4.2 || ^13.4",
-    "typo3/testing-framework": "^8.2.7"
-  },
-  "autoload": {
-    "psr-4": {
-      "WebVision\\Deepltranslate\\Glossary\\": "Classes"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "WebVision\\Deepltranslate\\Glossary\\Tests\\": "Tests"
-    }
-  },
-  "config": {
-    "allow-plugins": {
-      "ergebnis/composer-normalize": true,
-      "helhum/typo3-console-plugin": true,
-      "php-http/discovery": true,
-      "typo3/class-alias-loader": true,
-      "typo3/cms-composer-installers": true
-    },
-    "bin-dir": ".Build/bin",
-    "optimize-autoloader": true,
-    "sort-packages": true,
-    "vendor-dir": ".Build/vendor"
-  },
-  "extra": {
-    "typo3/cms": {
-      "app-dir": ".Build",
-      "extension-key": "deepltranslate_glossary",
-      "web-dir": ".Build/Web"
-    }
-  }
+	"name": "web-vision/deepltranslate-glossary",
+	"description": "This extension provides option to auto and renew translate within TYPO3 CMS",
+	"license": [
+		"GPL-2.0-or-later"
+	],
+	"type": "typo3-cms-extension",
+	"keywords": [
+		"TYPO3 CMS",
+		"extension",
+		"translate",
+		"deepl",
+		"glossary"
+	],
+	"authors": [
+		{
+			"name": "web-vision GmbH",
+			"email": "hello@web-vision.de",
+			"role": "Maintainer"
+		},
+		{
+			"name": "Mark Houben",
+			"email": "markhouben91@gmail.com",
+			"role": "Developer"
+		},
+		{
+			"name": "Markus Hofmann",
+			"email": "typo3@calien.de",
+			"role": "Developer"
+		},
+		{
+			"name": "Riad Zejnilagic Trumic",
+			"role": "Developer"
+		},
+		{
+			"name": "Stefan Bürk",
+			"role": "Developer",
+			"email": "stefan@buerk.tech"
+		}
+	],
+	"homepage": "https://www.web-vision.de/en/automated-translations-with-typo3-and-deepl.html",
+	"support": {
+		"issues": "https://github.com/web-vision/deepltranslate-glossary/issues",
+		"source": "https://github.com/web-vision/deepltranslate-glossary"
+	},
+	"require": {
+		"php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+		"ext-curl": "*",
+		"ext-json": "*",
+		"typo3/cms-backend": "^12.4.2 || ^13.4",
+		"typo3/cms-core": "^12.4.2 || ^13.4",
+		"web-vision/deepltranslate-core": "^5.0.0 || ~5.0@dev"
+	},
+	"require-dev": {
+		"friendsofphp/php-cs-fixer": "^3.64",
+		"php-mock/php-mock-phpunit": "^2.6",
+		"phpstan/phpstan": "^1.10",
+		"phpunit/phpunit": "^10.5",
+		"ramsey/uuid": "^4.7",
+		"saschaegerer/phpstan-typo3": "^1.9",
+		"typo3/cms-belog": "^12.4.2 || ^13.4",
+		"typo3/cms-install": "^12.4.2 || ^13.4",
+		"typo3/cms-lowlevel": "^12.4.2 || ^13.4",
+		"typo3/cms-rte-ckeditor": "^12.4.2 || ^13.4",
+		"typo3/cms-scheduler": "^12.4.2 || ^13.4",
+		"typo3/cms-setup": "^12.4.2 || ^13.4",
+		"typo3/cms-tstemplate": "^12.4.2 || ^13.4",
+		"typo3/cms-workspaces": "^12.4.2 || ^13.4",
+		"typo3/testing-framework": "^8.2.7"
+	},
+	"suggest": {
+		"typo3/cms-scheduler": "Add the scheduler for automatic synchronizing glossaries"
+	},
+	"autoload": {
+		"psr-4": {
+			"WebVision\\Deepltranslate\\Glossary\\": "Classes"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"WebVision\\Deepltranslate\\Glossary\\Tests\\": "Tests"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"ergebnis/composer-normalize": true,
+			"helhum/typo3-console-plugin": true,
+			"php-http/discovery": true,
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		},
+		"bin-dir": ".Build/bin",
+		"optimize-autoloader": true,
+		"sort-packages": true,
+		"vendor-dir": ".Build/vendor"
+	},
+	"extra": {
+		"typo3/cms": {
+			"app-dir": ".Build",
+			"extension-key": "deepltranslate_glossary",
+			"web-dir": ".Build/Web"
+		}
+	}
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,0 +1,37 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'DeepL Translate',
+    'description' => 'This extension provides option to translate content element, and TCA record texts to DeepL supported languages.',
+    'category' => 'backend',
+    'author' => 'web-vision GmbH Team',
+    'author_company' => 'web-vision GmbH',
+    'author_email' => 'hello@web-vision.de',
+    'state' => 'stable',
+    'version' => '5.0.0',
+    'constraints' => [
+        'depends' => [
+            'php' => '8.1.0-8.4.99',
+            'typo3' => '12.4.0-13.4.99',
+            'backend' => '12.4.0-13.4.99',
+            'setup' => '12.4.0-13.4.99',
+            'deepltranslate_core' => '5.0.0-5.99.99',
+        ],
+        'conflicts' => [
+            'wv_deepltranslate' => '*',
+        ],
+        'suggests' => [
+            'container' => '*',
+            'dashboard' => '*',
+            'install' => '*',
+            'enable_translated_content' => '*',
+            'deepltranslate_assets' => '*',
+            'scheduler' => '*',
+        ],
+    ],
+    'autoload' => [
+        'psr-4' => [
+            'WebVision\\Deepltranslate\\Core\\' => 'Classes',
+        ],
+    ],
+];


### PR DESCRIPTION
Glossary related code has been extracted from `web-vision/deepltranslate-core`
into this repository. To follow basic recommendations table naming has been
adjusted to match the new extension name.

To make the migration from core 4.x to 5.x with this addon a breeze, a
upgrade wizard is now provided to migrate existing data from old tables
to new tables.