### PR TITLE
[DOCS] Show correct composer install command in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Install with your favour:
 * [Git](https://github.com/web-vision/deepltranslate-glossary)
 
 We prefer composer installation:
+
 ```bash
-composer require web-vision/deepltranslate-core
+composer require web-vision/deepltranslate-glossary
 ```
 
 ## Sponsors


### PR DESCRIPTION
The installation section in the `README.md` provides   
the composer install command with the wrong package
name and states now the correct package name.  