### PR TITLE
[TASK] Add web-vision/deepl-base as testExtensionToLoad

### DIFF
--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -111,6 +111,8 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
      * @var non-empty-string[]
      */
     protected array $testExtensionsToLoad = [
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepl-base',
         'web-vision/deepltranslate-core',
         __DIR__ . '/Fixtures/Extensions/test_services_override',
     ];

--- a/Tests/Functional/Regression/GlossaryRegressionTest.php
+++ b/Tests/Functional/Regression/GlossaryRegressionTest.php
@@ -50,6 +50,8 @@ final class GlossaryRegressionTest extends AbstractDeepLTestCase
     ];
 
     protected array $testExtensionsToLoad = [
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepl-base',
         'web-vision/deepltranslate-core',
         'web-vision/deepltranslate-glossary',
         __DIR__ . '/../Fixtures/Extensions/test_services_override',

--- a/Tests/Functional/Upgrade/MigrateDeletedTablesFromOldStructureWizardTest.php
+++ b/Tests/Functional/Upgrade/MigrateDeletedTablesFromOldStructureWizardTest.php
@@ -11,6 +11,8 @@ use WebVision\Deepltranslate\Glossary\Upgrade\MigrateTablesFromOldStructureWizar
 final class MigrateDeletedTablesFromOldStructureWizardTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepl-base',
         'web-vision/deepltranslate-core',
         'web-vision/deepltranslate-glossary',
         __DIR__ . '/Fixtures/Extensions/test_migration_deleted',

--- a/Tests/Functional/Upgrade/MigrateTablesFromOldStructureWizardTest.php
+++ b/Tests/Functional/Upgrade/MigrateTablesFromOldStructureWizardTest.php
@@ -11,6 +11,8 @@ use WebVision\Deepltranslate\Glossary\Upgrade\MigrateTablesFromOldStructureWizar
 final class MigrateTablesFromOldStructureWizardTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepl-base',
         'web-vision/deepltranslate-core',
         'web-vision/deepltranslate-glossary',
         __DIR__ . '/Fixtures/Extensions/test_migration',


### PR DESCRIPTION
EXT:deepltranslate_core no longer ships the DeepL PHP
client and some TYPO3 core overrides has moved to a new
extension EXT:deepl_base and this change satifies the
test requirements for now.
