### PR TITLE
Fix glossary-cleanup-command call to remove glossary by deepl-id

### DIFF
--- a/Classes/Command/GlossaryCleanupCommand.php
+++ b/Classes/Command/GlossaryCleanupCommand.php
@@ -69,7 +69,7 @@ final class GlossaryCleanupCommand extends Command
         // Remove single glossary by deepl-id
         $glossaryId = $input->getOption('glossaryId');
         if ($glossaryId !== null) {
-            $this->removeGlossaries($glossaryId);
+            $this->removeGlossary($glossaryId);
         }
         // Remove all glossaries
         if (!empty($input->getOption('all'))) {


### PR DESCRIPTION
This fixes the removal of a glossary from DeepL by ID.

Calling `removeGlossaries()` instead of `removeGlossary()` with the ID string as a parameter does not work, as `removeGlossaries()` requires type `GlossaryInfo[]` as an input-parameter.