### PR TITLE
[BUGFIX] Avoid requiring unneeded refindex update for upgrade wizard

### DIFF
--- a/Classes/Upgrade/MigrateTablesFromOldStructureWizard.php
+++ b/Classes/Upgrade/MigrateTablesFromOldStructureWizard.php
@@ -9,7 +9,6 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
-use TYPO3\CMS\Install\Updates\ReferenceIndexUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 #[UpgradeWizard(identifier: 'deepltranslateGlossary_migrateGlossaryTables')]
@@ -109,7 +108,6 @@ final class MigrateTablesFromOldStructureWizard implements UpgradeWizardInterfac
     {
         return [
             DatabaseUpdatedPrerequisite::class,
-            ReferenceIndexUpdatedPrerequisite::class,
         ];
     }
 


### PR DESCRIPTION
The `MigrateTablesFromOldStructureWizard` declared the
requirement to have a clean `RefIndex` and enforced a
realy heavy operation, which was never needed because
the upgrade wizard does not use or process any actions
based on the refindex and the state is unrelated.

To reduce the cost for instances upgrading to the `5.x`
version we remove the prerequisite now and literally
avoiding long delays with larger instance databases.

Resolves: #22
Co-Authored-By: Oz <oz-agent@warp.dev>
