### PR TITLE
[TASK] DPL-160: Ensure working compatibility with Glossary API v2

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -514,6 +514,7 @@ case ${TEST_SUITE} in
         cleanCacheFiles
         # backup current composer.json
         cp -Rf composer.json composer.json.orig
+        rm -rf .Build/vendor
         ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-update-${CORE_VERSION}-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} composer require --dev "typo3/minimal":"^${CORE_VERSION}"
         SUITE_EXIT_CODE=$?
         # restore composer json

--- a/Build/phpstan/Core13/phpstan.neon
+++ b/Build/phpstan/Core13/phpstan.neon
@@ -5,6 +5,7 @@ includes:
 parameters:
   # Use local .cache dir instead of /tmp
   tmpDir: ../../../.cache/phpstan
+  treatPhpDocTypesAsCertain: false
 
   level: 8
 

--- a/Build/phpstan/Core14/phpstan.neon
+++ b/Build/phpstan/Core14/phpstan.neon
@@ -5,6 +5,7 @@ includes:
 parameters:
   # Use local .cache dir instead of /tmp
   tmpDir: ../../../.cache/phpstan
+  treatPhpDocTypesAsCertain: false
 
   level: 8
 

--- a/Classes/Client/GlossaryAPIV2Client.php
+++ b/Classes/Client/GlossaryAPIV2Client.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Client;
+
+use DeepL\DeepLException;
+use DeepL\GlossaryEntries;
+use DeepL\GlossaryInfo;
+use DeepL\GlossaryLanguagePair;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use WebVision\Deepltranslate\Core\AbstractClient;
+use WebVision\Deepltranslate\Core\Client\DeepLClientFactoryInterface;
+
+/**
+ * Client implementation for Glossary API v2, see {@see GlossaryAPIV2ClientInterface}.
+ * @internal No public API.
+ */
+#[AsAlias(id: GlossaryAPIV2ClientInterface::class, public: true)]
+final class GlossaryAPIV2Client extends AbstractClient implements GlossaryAPIV2ClientInterface
+{
+    /**
+     * @internal
+     * @todo typo3/cms-core:>=13.4.29 Replace constructor with `inject*()` methods in {@see AbstractClient},
+     *       link: https://review.typo3.org/c/Packages/TYPO3.CMS/+/89244
+     */
+    public function __construct(
+        protected LoggerInterface $logger,
+        protected DeepLClientFactoryInterface $clientFactory,
+    ) {
+    }
+
+    /**
+     * @return GlossaryLanguagePair[]
+     */
+    public function getGlossaryLanguagePairs(): array
+    {
+        try {
+            return $this->client()->getGlossaryLanguages();
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return [];
+    }
+
+    /**
+     * @return GlossaryInfo[]
+     */
+    public function getAllGlossaries(): array
+    {
+        try {
+            return $this->client()->listGlossaries();
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return [];
+    }
+
+    /**
+     * DeepL Glossary API v2
+     *
+     * @depreacted will be removed as soon as DeepL API drops support for v2
+     */
+    public function getGlossary(string $glossaryId): ?GlossaryInfo
+    {
+        try {
+            return $this->client()->getGlossary($glossaryId);
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return null;
+    }
+
+    /**
+     * DeepL Glossary API v2
+     *
+     * @depreacted will be removed as soon as DeepL API drops support for v2
+     * @param array<int, array{source: string, target: string}> $entries
+     */
+    public function createGlossary(
+        string $glossaryName,
+        string $sourceLang,
+        string $targetLang,
+        array $entries
+    ): GlossaryInfo {
+        $prepareEntriesForGlossary = [];
+        foreach ($entries as $entry) {
+            /*
+             * as the version without trimming in TCA is already published,
+             * we trim a second time here
+             * to avoid errors in DeepL client
+             */
+            $source = trim($entry['source']);
+            $target = trim($entry['target']);
+            if (empty($source) || empty($target)) {
+                continue;
+            }
+            $prepareEntriesForGlossary[$source] = $target;
+        }
+        try {
+            return $this->client()->createGlossary(
+                $glossaryName,
+                $sourceLang,
+                $targetLang,
+                GlossaryEntries::fromEntries($prepareEntriesForGlossary)
+            );
+        } catch (DeepLException $e) {
+            return new GlossaryInfo(
+                '',
+                '',
+                false,
+                '',
+                '',
+                new \DateTime(),
+                0
+            );
+        }
+    }
+
+    /**
+     * DeepL Glossary API v2
+     *
+     * @depreacted will be removed as soon as DeepL API drops support for v2
+     */
+    public function deleteGlossary(string $glossaryId): void
+    {
+        try {
+            $this->client()->deleteGlossary($glossaryId);
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+    }
+
+    /**
+     * DeepL Glossary API v2
+     *
+     * @depreacted will be removed as soon as DeepL API drops support for v2
+     */
+    public function getGlossaryEntries(string $glossaryId): ?GlossaryEntries
+    {
+        try {
+            return $this->client()->getGlossaryEntries($glossaryId);
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return null;
+    }
+}

--- a/Classes/Client/GlossaryAPIV2ClientInterface.php
+++ b/Classes/Client/GlossaryAPIV2ClientInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Client;
+
+use DeepL\GlossaryEntries;
+use DeepL\GlossaryInfo;
+use DeepL\GlossaryLanguagePair;
+use WebVision\Deepltranslate\Core\ClientInterface as DeepltranslateCoreClientInterface;
+use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
+
+/**
+ * Describes required implementation for Glossary API v2 compatible client implementations.
+ * @depreacted in favour of upcoming GlossaryV3Interace and APIv3 handling.
+ * @internal and not public API yet. Kept for refactoring towards APIv3.
+ */
+interface GlossaryAPIV2ClientInterface extends DeepltranslateCoreClientInterface
+{
+    /**
+     * @return GlossaryLanguagePair[]
+     *
+     * @throws ApiKeyNotSetException
+     */
+    public function getGlossaryLanguagePairs(): array;
+
+    /**
+     * @return GlossaryInfo[]
+     *
+     * @throws ApiKeyNotSetException
+     * @deprecated This function is deprecated in favour of multilingual glossaries and will be removed in future versions
+     */
+    public function getAllGlossaries(): array;
+
+    /**
+     * @throws ApiKeyNotSetException
+     * @deprecated This function is deprecated in favour of multilingual glossaries and will be removed in future versions
+     */
+    public function getGlossary(string $glossaryId): ?GlossaryInfo;
+
+    /**
+     * @param array<int, array{source: string, target: string}> $entries
+     *
+     * @throws ApiKeyNotSetException
+     * @deprecated This function is deprecated in favour of multilingual glossaries and will be removed in future versions
+     */
+    public function createGlossary(
+        string $glossaryName,
+        string $sourceLang,
+        string $targetLang,
+        array $entries
+    ): GlossaryInfo;
+
+    /**
+     * @throws ApiKeyNotSetException
+     * @deprecated This function is deprecated in favour of multilingual glossaries and will be removed in future versions
+     */
+    public function deleteGlossary(string $glossaryId): void;
+
+    /**
+     * @throws ApiKeyNotSetException
+     * @deprecated This function is deprecated in favour of multilingual glossaries and will be removed in future versions
+     */
+    public function getGlossaryEntries(string $glossaryId): ?GlossaryEntries;
+}

--- a/Classes/Client/GlossaryAPIV3Client.php
+++ b/Classes/Client/GlossaryAPIV3Client.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Client;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use WebVision\Deepltranslate\Core\AbstractClient;
+use WebVision\Deepltranslate\Core\Client\DeepLClientFactoryInterface;
+
+/**
+ * Client implementation for Glossary API v2, see {@see GlossaryAPIV2ClientInterface}.
+ * @internal No public API.
+ */
+#[AsAlias(id: GlossaryAPIV3ClientInterface::class, public: true)]
+final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3ClientInterface
+{
+    /**
+     * @internal
+     * @todo typo3/cms-core:>=13.4.29 Replace constructor with `inject*()` methods in {@see AbstractClient},
+     *       link: https://review.typo3.org/c/Packages/TYPO3.CMS/+/89244
+     */
+    public function __construct(
+        protected LoggerInterface $logger,
+        protected DeepLClientFactoryInterface $clientFactory,
+    ) {
+    }
+}

--- a/Classes/Client/GlossaryAPIV3ClientInterface.php
+++ b/Classes/Client/GlossaryAPIV3ClientInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Client;
+
+use WebVision\Deepltranslate\Core\ClientInterface as DeepltranslateCoreClientInterface;
+
+/**
+ * Describes required implementation for Glossary API v3 compatible client implementations.
+ * @internal and not public API yet. Methods will be added in minor versions implementing this API version.
+ */
+interface GlossaryAPIV3ClientInterface extends DeepltranslateCoreClientInterface
+{
+}

--- a/Classes/Hooks/UpdatedGlossaryEntryTermHook.php
+++ b/Classes/Hooks/UpdatedGlossaryEntryTermHook.php
@@ -6,6 +6,7 @@ namespace WebVision\Deepltranslate\Glossary\Hooks;
 
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception as DBALException;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -18,6 +19,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryEntryRepository;
 use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
 
+#[Autoconfigure(public: true)]
 final class UpdatedGlossaryEntryTermHook
 {
     private LanguageService $languageService;

--- a/Classes/Service/DeeplGlossaryService.php
+++ b/Classes/Service/DeeplGlossaryService.php
@@ -9,29 +9,24 @@ use DeepL\GlossaryEntries;
 use DeepL\GlossaryInfo;
 use DeepL\GlossaryLanguagePair;
 use Doctrine\DBAL\Driver\Exception;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
-use WebVision\Deepltranslate\Core\ClientInterface;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV2ClientInterface;
 use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
 use WebVision\Deepltranslate\Glossary\Exception\FailedToCreateGlossaryException;
 use WebVision\Deepltranslate\Glossary\Exception\GlossaryEntriesNotExistException;
 
-final class DeeplGlossaryService
+#[Autoconfigure(public: true)]
+final readonly class DeeplGlossaryService
 {
-    private ClientInterface $client;
-
-    private FrontendInterface $cache;
-
-    protected GlossaryRepository $glossaryRepository;
-
     public function __construct(
-        FrontendInterface $cache,
-        ClientInterface $client,
-        GlossaryRepository $glossaryRepository
+        #[Autowire(service: 'cache.deepltranslate_glossary')]
+        private FrontendInterface $cache,
+        private GlossaryAPIV2ClientInterface $client,
+        private GlossaryRepository $glossaryRepository,
     ) {
-        $this->cache = $cache;
-        $this->client = $client;
-        $this->glossaryRepository = $glossaryRepository;
     }
 
     /**

--- a/Classes/Upgrade/MigrateTablesFromOldStructureWizard.php
+++ b/Classes/Upgrade/MigrateTablesFromOldStructureWizard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Upgrade;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -12,11 +13,12 @@ use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 #[UpgradeWizard(identifier: 'deepltranslateGlossary_migrateGlossaryTables')]
-final class MigrateTablesFromOldStructureWizard implements UpgradeWizardInterface
+final readonly class MigrateTablesFromOldStructureWizard implements UpgradeWizardInterface
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
-        private readonly FrontendInterface $cache
+        private ConnectionPool $connectionPool,
+        #[Autowire(service: 'cache.runtime')]
+        private FrontendInterface $cache,
     ) {
     }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,15 +13,3 @@ services:
     resource: '../Classes/*'
     exclude:
       - '../Classes/Domain/Model/*'
-
-  WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService:
-    public: true
-    arguments:
-      $cache: '@cache.deepltranslate_glossary'
-
-  WebVision\Deepltranslate\Glossary\Upgrade\MigrateTablesFromOldStructureWizard:
-    arguments:
-      $cache: '@cache.runtime'
-
-  WebVision\Deepltranslate\Glossary\Hooks\UpdatedGlossaryEntryTermHook:
-    public: true

--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -4,62 +4,22 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Tests\Functional;
 
-use Closure;
-use DeepL\Translator;
-use DeepL\TranslatorOptions;
-use Exception;
-use phpmock\phpunit\PHPMock;
-use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
-use RuntimeException;
 use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
-use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Utility\StringUtility;
-use WebVision\Deepltranslate\Core\Client;
-use WebVision\Deepltranslate\Core\ClientInterface;
-use WebVision\Deepltranslate\Core\ConfigurationInterface;
 
+/**
+ * This Test case class defines basic setup for working with the DeepL mock server automatically loaded inside the
+ * projects runTests.sh.
+ *
+ * It takes care of different mock instances and works with separate server connections depending on the test identifier
+ * to avoid issues due to not teared down data inside the DeepL mock server.
+ */
 abstract class AbstractDeepLTestCase extends FunctionalTestCase
 {
-    use PHPMock;
-
     /**
-     * @var string
-     */
-    protected $authKey = 'mock_server';
-
-    /**
-     * @var string|false
-     */
-    protected $serverUrl = false;
-
-    /**
-     * @var string|false
-     */
-    protected $proxyUrl = false;
-
-    protected bool $isMockServer = false;
-
-    protected bool $isMockProxyServer = false;
-
-    protected ?string $sessionNoResponse = null;
-
-    protected ?string $session429Count = null;
-    protected ?string $sessionInitCharacterLimit = null;
-
-    protected ?string $sessionInitDocumentLimit = null;
-
-    protected ?string $sessionInitTeamDocumentLimit = null;
-
-    protected ?string $sessionDocFailure = null;
-
-    protected ?int $sessionDocQueueTime = null;
-
-    protected ?int $sessionDocTranslateTime = null;
-
-    protected ?bool $sessionExpectProxy = null;
-
-    /**
+     * Defines the possible translations by the DeepL mock server to use in tests and assertions.
+     *
      * @var array<non-empty-string, non-empty-string>
      */
     protected const EXAMPLE_TEXT = [
@@ -98,6 +58,46 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         'zh' => '质子束',
     ];
 
+    protected const EXAMPLE_DOCUMENT_INPUT = AbstractDeepLTestCase::EXAMPLE_TEXT['en'];
+
+    protected const EXAMPLE_DOCUMENT_OUTPUT = AbstractDeepLTestCase::EXAMPLE_TEXT['de'];
+
+    /**
+     * @var string
+     */
+    protected $authKey = 'mock_server';
+
+    /**
+     * @var string|false
+     */
+    protected $serverUrl = false;
+
+    /**
+     * @var string|false
+     */
+    protected $proxyUrl = false;
+
+    protected bool $isMockServer = false;
+
+    protected bool $isMockProxyServer = false;
+
+    protected ?string $sessionNoResponse = null;
+
+    protected ?string $session429Count = null;
+    protected ?string $sessionInitCharacterLimit = null;
+
+    protected ?string $sessionInitDocumentLimit = null;
+
+    protected ?string $sessionInitTeamDocumentLimit = null;
+
+    protected ?string $sessionDocFailure = null;
+
+    protected ?int $sessionDocQueueTime = null;
+
+    protected ?int $sessionDocTranslateTime = null;
+
+    protected ?bool $sessionExpectProxy = null;
+
     /**
      * @var non-empty-string[]
      */
@@ -111,20 +111,23 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
      * @var non-empty-string[]
      */
     protected array $testExtensionsToLoad = [
-        'web-vision/deeplcom-deepl-php',
         'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
         'web-vision/deepltranslate-core',
         'web-vision/deepltranslate-glossary',
-        'web-vision/test-services-override',
     ];
-
-    protected const EXAMPLE_DOCUMENT_INPUT = AbstractDeepLTestCase::EXAMPLE_TEXT['en'];
-
-    protected const EXAMPLE_DOCUMENT_OUTPUT = AbstractDeepLTestCase::EXAMPLE_TEXT['de'];
 
     protected string $EXAMPLE_LARGE_DOCUMENT_INPUT = '';
 
     protected string $EXAMPLE_LARGE_DOCUMENT_OUTPUT = '';
+
+    protected array $configurationToUseInTestInstance = [
+        'EXTENSIONS' => [
+            'deepltranslate_core' => [
+                'apiKey' => 'mock_server',
+            ],
+        ],
+    ];
 
     protected function setUp(): void
     {
@@ -138,22 +141,24 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         if ($this->isMockServer) {
             $this->authKey = 'mock_server';
             if ($this->serverUrl === false) {
-                throw new RuntimeException(
+                throw new \RuntimeException(
                     'DEEPL_SERVER_URL environment variable must be set if using a mock server',
                     1733938285,
                 );
             }
         } else {
             if (getenv('DEEPL_AUTH_KEY') === false) {
-                throw new RuntimeException(
+                throw new \RuntimeException(
                     'DEEPL_AUTH_KEY environment variable must be set unless using a mock server',
                     1733938290,
                 );
             }
             $this->authKey = getenv('DEEPL_AUTH_KEY') ?: '';
         }
+        $this->configurationToUseInTestInstance['EXTENSIONS']['deepltranslate_core']['apiKey'] = self::getInstanceIdentifier();
+        $GLOBALS['DEEPL_TESTING']['SERVER_URL'] = $this->serverUrl;
+        $GLOBALS['DEEPL_TESTING']['HEADERS'] = $this->sessionHeaders();
         parent::setUp();
-        $this->instantiateMockServerClient();
     }
 
     private function makeSessionName(): string
@@ -198,43 +203,6 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         return $headers;
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    protected function instantiateMockServerClient(array $options = []): void
-    {
-        $mergedOptions = array_replace(
-            [TranslatorOptions::HEADERS => $this->sessionHeaders()],
-            $options
-        );
-        if ($this->serverUrl !== false) {
-            $mergedOptions[TranslatorOptions::SERVER_URL] = $this->serverUrl;
-        }
-        $mockConfiguration = $this
-            ->getMockBuilder(ConfigurationInterface::class)
-            ->getMock();
-        $mockConfiguration
-            ->method('getApiKey')
-            ->willReturn(self::getInstanceIdentifier());
-
-        $client = new Client($mockConfiguration);
-        $client->setLogger(new NullLogger());
-
-        // use closure to set private option for translation
-        $translator = new Translator(self::getInstanceIdentifier(), $mergedOptions);
-        Closure::bind(
-            function (Translator $translator) {
-                $this->translator = $translator;
-            },
-            $client,
-            Client::class
-        )->call($client, $translator);
-
-        /** @var Container $container */
-        $container = $this->getContainer();
-        $container->set(ClientInterface::class, $client);
-    }
-
     public static function readFile(string $filepath): string
     {
         $size = filesize($filepath);
@@ -244,7 +212,6 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         $fh = fopen($filepath, 'r');
         $size = filesize($filepath);
         $content = '';
-        /** @phpstan-ignore notIdentical.alwaysTrue */
         if ($fh !== false && $size !== false) {
             $content = fread($fh, $size);
             fclose($fh);
@@ -278,44 +245,28 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         return [$tempDir, $exampleDocument, $exampleLargeDocument, $outputDocumentPath];
     }
 
-    public function assertExceptionContains(string $needle, callable $function): Exception
+    public function assertExceptionContains(string $needle, callable $function): \Exception
     {
         try {
             $function();
-        } catch (Exception $exception) {
-            static::assertStringContainsString($needle, $exception->getMessage());
+        } catch (\Exception $exception) {
+            $this->assertStringContainsString($needle, $exception->getMessage());
             return $exception;
         }
-        static::fail("Expected exception containing '$needle' but nothing was thrown");
+        $this->fail("Expected exception containing '$needle' but nothing was thrown");
     }
 
     /**
      * @param class-string $class
      */
-    public function assertExceptionClass(string $class, callable $function): Exception
+    public function assertExceptionClass(string $class, callable $function): \Exception
     {
         try {
             $function();
-        } catch (Exception $exception) {
-            static::assertEquals($class, get_class($exception));
+        } catch (\Exception $exception) {
+            $this->assertEquals($class, get_class($exception));
             return $exception;
         }
-        static::fail("Expected exception of class '$class' but nothing was thrown");
-    }
-
-    /**
-     * This is necessary due to https://github.com/php-mock/php-mock-phpunit#restrictions
-     * In short, as these methods can be called by other tests before UserAgentTest and other
-     * tests that use their mocks are executed, we need to call `defineFunctionMock` before
-     * calling the unmocked function, or the mock will not work.
-     * Otherwise the tests will fail with:
-     *     Expectation failed for method name is "delegate" when invoked 1 time(s).
-     *     Method was expected to be called 1 times, actually called 0 times.
-     */
-    public static function setUpBeforeClass(): void
-    {
-        self::defineFunctionMock(__NAMESPACE__, 'curl_exec');
-        self::defineFunctionMock(__NAMESPACE__, 'curl_getinfo');
-        self::defineFunctionMock(__NAMESPACE__, 'curl_setopt_array');
+        $this->fail("Expected exception of class '$class' but nothing was thrown");
     }
 }

--- a/Tests/Functional/Client/GlossaryV2ClientTest.php
+++ b/Tests/Functional/Client/GlossaryV2ClientTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Client;
+
+use DeepL\GlossaryEntries;
+use DeepL\GlossaryInfo;
+use DeepL\GlossaryLanguagePair;
+use PHPUnit\Framework\Attributes\Test;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV2ClientInterface;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+final class GlossaryV2ClientTest extends AbstractDeepLTestCase
+{
+    #[Test]
+    public function checkResponseFromGlossaryLanguagePairs(): void
+    {
+        $client = $this->get(GlossaryAPIV2ClientInterface::class);
+        $response = $client->getGlossaryLanguagePairs();
+
+        $this->assertIsArray($response);
+        $this->assertContainsOnlyInstancesOf(GlossaryLanguagePair::class, $response);
+    }
+
+    #[Test]
+    public function checkResponseFromCreateGlossary(): void
+    {
+        $client = $this->get(GlossaryAPIV2ClientInterface::class);
+        $response = $client->createGlossary(
+            'Deepl-Client-Create-Function-Test:' . __FUNCTION__,
+            'de',
+            'en',
+            [
+                0 => [
+                    'source' => 'hallo Welt',
+                    'target' => 'hello world',
+                ],
+            ],
+        );
+
+        $this->assertInstanceOf(GlossaryInfo::class, $response);
+        $this->assertSame(1, $response->entryCount);
+        $this->assertIsString($response->glossaryId);
+        $this->assertInstanceOf(\DateTime::class, $response->creationTime);
+    }
+
+    #[Test]
+    public function checkResponseGetAllGlossaries(): void
+    {
+        $client = $this->get(GlossaryAPIV2ClientInterface::class);
+        $response = $client->getAllGlossaries();
+
+        $this->assertIsArray($response);
+        $this->assertContainsOnlyInstancesOf(GlossaryInfo::class, $response);
+    }
+
+    #[Test]
+    public function checkResponseFromGetGlossary(): void
+    {
+        $client = $this->get(GlossaryAPIV2ClientInterface::class);
+        $glossary = $client->createGlossary(
+            'Deepl-Client-Create-Function-Test:' . __FUNCTION__,
+            'de',
+            'en',
+            [
+                0 => [
+                    'source' => 'hallo Welt',
+                    'target' => 'hello world',
+                ],
+            ],
+        );
+
+        $response = $client->getGlossary($glossary->glossaryId);
+
+        $this->assertInstanceOf(GlossaryInfo::class, $response);
+        $this->assertSame($glossary->glossaryId, $response->glossaryId);
+        $this->assertSame(1, $response->entryCount);
+    }
+
+    #[Test]
+    public function checkGlossaryDeletedNotCatchable(): void
+    {
+        $client = $this->get(GlossaryAPIV2ClientInterface::class);
+        $glossary = $client->createGlossary(
+            'Deepl-Client-Create-Function-Test' . __FUNCTION__,
+            'de',
+            'en',
+            [
+                0 => [
+                    'source' => 'hallo Welt',
+                    'target' => 'hello world',
+                ],
+            ],
+        );
+
+        $glossaryId = $glossary->glossaryId;
+
+        $client->deleteGlossary($glossaryId);
+
+        $this->assertNull($client->getGlossary($glossaryId));
+    }
+
+    #[Test]
+    public function checkResponseFromGetGlossaryEntries(): void
+    {
+        $client = $this->get(GlossaryAPIV2ClientInterface::class);
+        $glossary = $client->createGlossary(
+            'Deepl-Client-Create-Function-Test:' . __FUNCTION__,
+            'de',
+            'en',
+            [
+                0 => [
+                    'source' => 'hallo Welt',
+                    'target' => 'hello world',
+                ],
+            ],
+        );
+
+        $response = $client->getGlossaryEntries($glossary->glossaryId);
+
+        $this->assertInstanceOf(GlossaryEntries::class, $response);
+        $this->assertSame(1, count($response->getEntries()));
+    }
+}


### PR DESCRIPTION
`EXT:deepltranslate_core` refactors the DeepL client structure
shared across all `WebVision DeepL Ecosystem` extensions [1].
This prepares future support for `Glossary API v3`, including
multilingual glossaries, bidirectional synchronization, and
import/export capabilities.

Enhanced glossary support is a highly requested feature and
will be delivered in a follow-up change. For now, this patch
restores the `Glossary API v2` implementation to ensure a
working baseline compatible with TYPO3 v13 and v14.

This is based on the refactoring inn `EXT:deeptranslate_core`
and the dedicated, splitted client implementation, and opens
the ability to deal with the Glossary API versions directly
within `EXT:deepltranslate_glossary` regarding interfaces and
client implementation. That reduces roundtrips in the future
between these two extensions. [1]

Next-generation glossary integration will be introduced as a
separate feature in a minor release of `deepltranslate_glossary`.

[1] https://github.com/web-vision/deepltranslate-core/pull/493
