### PR TITLE
[TASK] DPL-158: Streamline GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
@@ -68,8 +68,7 @@ jobs:
       # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
       # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
       - name: Create release and upload artifacts in the same step
-        # @todo Revert to release version when https://github.com/softprops/action-gh-release/issues/628 is fixed.
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
+        uses: softprops/action-gh-release@v2
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
           name: "[RELEASE] ${{ env.version }}"

--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -11,43 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.1']
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
+        php-version: [ '8.1' ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v12"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
-
-#      - name: "Run TypoScript lint"
-#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintTypoScript"
 
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
@@ -77,37 +47,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.1', '8.2', '8.3' ]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
+        php-version: [ '8.1', '8.4' ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v12"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -11,43 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.2']
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
+        php-version: [ '8.2' ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
-
-#      - name: "Run TypoScript lint"
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintTypoScript"
 
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintPhp"
@@ -67,8 +37,8 @@ jobs:
       - name: "Find duplicate exception codes"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
-#      - name: "Run PHPStan"
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s phpstan"
+      - name: "Run PHPStan"
+        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s phpstan"
 
   testsuite:
     name: all tests with core v13
@@ -77,37 +47,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
+        php-version: [ '8.2', '8.5' ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composerUpdate"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -221,12 +221,13 @@ Options:
             - 12: (default) use TYPO3 v12
             - 12: use TYPO3 v13
 
-    -p <8.1|8.2|8.3|8.4>
+    -p <8.1|8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
             - 8.1: use PHP 8.1
             - 8.2: (default) use PHP 8.2
             - 8.3: use PHP 8.3
             - 8.4: use PHP 8.4
+            - 8.5: use PHP 8.5
 
     -x
         Only with -s functional|functionalDeprecated|unit|unitDeprecated|unitRandom|acceptance|acceptanceInstall
@@ -333,7 +334,7 @@ while getopts "a:b:s:d:i:p:t:xy:o:nhu" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4|8.5)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#3 \\$severity of class TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage constructor expects TYPO3\\\\CMS\\\\Core\\\\Type\\\\ContextualFeedbackSeverity, int given\\.$#"
-			count: 1
-			path: ../../../Classes/Controller/GlossarySyncController.php
-
-		-
 			message: "#^Method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Connection\\:\\:lastInsertId\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: ../../../Classes/Domain/Repository/GlossaryRepository.php

--- a/Classes/Controller/GlossarySyncController.php
+++ b/Classes/Controller/GlossarySyncController.php
@@ -54,7 +54,7 @@ final class GlossarySyncController
                 ->enqueue((new FlashMessage(
                     'No ID given for glossary synchronization',
                     '',
-                    2,
+                    ContextualFeedbackSeverity::ERROR,
                     true
                 )));
             return new RedirectResponse($processingParameters['returnUrl']);

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -258,7 +259,13 @@ final class GlossaryRepository
             $db = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getConnectionForTable('tx_deepltranslate_glossary');
             $db->insert('tx_deepltranslate_glossary', $insert);
-            $lastInsertId = $db->lastInsertId('tx_deepltranslate_glossary');
+            if ((new Typo3Version())->getMajorVersion() === 12) {
+                // @todo typo3/cms-core:>13.4 Remove this with the whole if-block handling lowest supported TYPO3 version is raised to 13.4.
+                $lastInsertId = $db->lastInsertId('tx_deepltranslate_glossary');
+            } else {
+                // @todo typo3/cms-core:>13.4 Keep this line when lowest supported TYPO3 version is raised to 13.4.
+                $lastInsertId = $db->lastInsertId();
+            }
             $insert['uid'] = $lastInsertId;
             unset($insert['pid']);
             return Glossary::fromDatabase($insert);


### PR DESCRIPTION
This change streamlines the GitHub actions,
which includes:

* Executing tests only with the lowest and
  highest PHP versionion supported by the
  TYPO3 version to reduce the matrix without
  loosing anything in reality.

* Updates used GitHub actions to latest versions.

* Reduces or removes action job permissions.

* Generate baseline to drop two ignore patterns no
  longer matching against TYPO3 v13 and enable the
  phpstan integrity check in the GitHub action now.

* Remove `TypoScript` linking completly, can be added
  again if TypoScript is added to the extension.

* Use `ContextualFeedbackSeverity::ERROR` instead of
  integer value one place to avoid TypeError in TYPO3
  v13. Literally a bug, but fixed as sidechange now.

* TYPO3 version aware `lastInsertId()` handling is now
  added to `GlossaryRepository` to mitigate phpstan
  reporting for TYPO3 v13 and document it right away.

* Allow `PHP 8.5` with `Build/Scripts/runTests.sh`.

Used command(s):

```bash
Build/Scripts/runTests.sh \
  -p 8.1 -t 12 -s composerUpdate \
&& Build/Scripts/runTests.sh \
  -p 8.1 -t 12 -s phpstanGenerateBaseline \
&& Build/Scripts/runTests.sh \
  -p 8.2 -t 13 -s composerUpdate \
&& Build/Scripts/runTests.sh \
  -p 8.2 -t 13 -s phpstanGenerateBaseline \
&& Build/Scripts/runTests.sh \
  -p 8.1 -t 12 -s composerUpdate
```