### PR TITLE
[TASK] DPL-158: Add basic supported TYPO3 version tests

### DIFF
--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -14,7 +14,6 @@ use Ramsey\Uuid\Uuid;
 use RuntimeException;
 use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use Symfony\Component\DependencyInjection\Container;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\StringUtility;
 use WebVision\Deepltranslate\Core\Client;
 use WebVision\Deepltranslate\Core\ClientInterface;
@@ -105,6 +104,7 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'typo3/cms-setup',
         'typo3/cms-scheduler',
+        'typo3/cms-install',
     ];
 
     /**
@@ -114,6 +114,7 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         'web-vision/deeplcom-deepl-php',
         'web-vision/deepl-base',
         'web-vision/deepltranslate-core',
+        'web-vision/deepltranslate-glossary',
         __DIR__ . '/Fixtures/Extensions/test_services_override',
     ];
 
@@ -127,9 +128,6 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        if ((new Typo3Version())->getMajorVersion() >= 13) {
-            $this->coreExtensionsToLoad[] = 'typo3/cms-install';
-        }
         $this->EXAMPLE_LARGE_DOCUMENT_INPUT = str_repeat(AbstractDeepLTestCase::EXAMPLE_TEXT['en'] . PHP_EOL, 1000);
         $this->EXAMPLE_LARGE_DOCUMENT_OUTPUT = str_repeat(AbstractDeepLTestCase::EXAMPLE_TEXT['de'] . PHP_EOL, 1000);
         $this->serverUrl = getenv('DEEPL_SERVER_URL');

--- a/Tests/Functional/ExtensionLoadedTest.php
+++ b/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractDeepLTestCase
+{
+    private const ALLOWED_MAJOR_VERSIONS = [13, 14];
+
+    public static function loadedExtensionsDataSet(): \Generator
+    {
+        $packages = [
+            'deepltranslate_core' => 'web-vision/deepltranslate-core',
+            'deepltranslate_glossary' => 'web-vision/deepltranslate-glossary',
+            'deepl_base' => 'web-vision/deepl-base',
+            'deeplcom_deeplphp' => 'web-vision/deeplcom-deepl-php',
+        ];
+        foreach ($packages as $extensionKey => $packageName) {
+            yield 'EXT:' . $extensionKey => ['identifier' => $extensionKey];
+            yield $packageName => ['identifier' => $packageName];
+        }
+    }
+
+    #[DataProvider('loadedExtensionsDataSet')]
+    #[Test]
+    public function isLoadedExtensionKey(string $identifier): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded($identifier), $identifier);
+    }
+
+    #[Test]
+    public function allowedMajorTypo3Version(): void
+    {
+        $this->assertContains((new Typo3Version())->getMajorVersion(), self::ALLOWED_MAJOR_VERSIONS);
+    }
+
+    #[Group('not-core-14')]
+    #[Test]
+    public function verifyCore13(): void
+    {
+        $this->markTestSkipped('Needs phpunit update first');
+        //$this->assertSame(13, (new Typo3Version())->getMajorVersion());
+    }
+
+    #[Group('not-core-13')]
+    #[Test]
+    public function verifyCore14(): void
+    {
+        $this->markTestSkipped('Needs phpunit update first');
+        //$this->assertSame(14, (new Typo3Version())->getMajorVersion());
+    }
+}

--- a/Tests/Unit/VersionTest.php
+++ b/Tests/Unit/VersionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class VersionTest extends UnitTestCase
+{
+    private const ALLOWED_MAJOR_VERSIONS = [13, 14];
+
+    #[Test]
+    public function allowedMajorTypo3Version(): void
+    {
+        $this->assertContains((new Typo3Version())->getMajorVersion(), self::ALLOWED_MAJOR_VERSIONS);
+    }
+
+    #[Group('not-core-14')]
+    #[Test]
+    public function verifyCore13(): void
+    {
+        $this->markTestSkipped('Needs phpunit update first');
+        //$this->assertSame(13, (new Typo3Version())->getMajorVersion());
+    }
+
+    #[Group('not-core-13')]
+    #[Test]
+    public function verifyCore14(): void
+    {
+        $this->markTestSkipped('Needs phpunit update first');
+        //$this->assertSame(14, (new Typo3Version())->getMajorVersion());
+    }
+}


### PR DESCRIPTION
This change adds basic unit and functional test to cover
supported TYPO3 version and also verifies that correct
TYPO3 version is installed for executed tests to prevent
issues in GitHub pipelines in case composer install goes
wrong and undetected because if error handling the non-zero
exit code.
