### PR TITLE
[TASK] DPL-158: Allow installation with `TYPO3 ~14.2.0@dev`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,12 +53,18 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+
+      - name: Set composer.json version and extra.typo3/cms.version
+        run: |
+          composer config "version" "${{ env.version }}" \
+          && composer config "extra"."typo3/cms"."version" "${{ env.version }}" \
+          && composer validate --strict --no-check-lock --no-check-version
 
       # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
       - name: Create local TER package upload artifact

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -19,6 +19,9 @@ jobs:
       - name: "Prepare dependencies for TYPO3 v13"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
 
+      - name: "Validate composer.json"
+        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composer -- validate --strict --no-check-lock --no-check-version"
+
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintPhp"
 

--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -1,0 +1,93 @@
+name: tests core 14
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  code-quality:
+    name: "code quality with core v14"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '8.2' ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Prepare dependencies for TYPO3 v14"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Validate composer.json"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s composer -- validate --strict --no-check-lock --no-check-version"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s lintPhp"
+
+      - name: "Validate CGL"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s cgl -n"
+
+      - name: "Ensure tests methods do not start with \"test\""
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+
+      - name: "Ensure UTF-8 files do not contain BOM"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkBom"
+
+#      - name: "Test .rst files for integrity"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkRst"
+
+      - name: "Find duplicate exception codes"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+
+# @todo Disabled due to following finding with `-t 14 -s phpstan`:
+#
+#  ------ -----------------------------------------------------------------------
+#  Line   Classes/EventListener/GlossarySyncButtonProvider.php
+#  ------ -----------------------------------------------------------------------
+#  85     Access to undefined constant TYPO3\CMS\Core\Imaging\Icon::SIZE_SMALL.
+#  🪪  classConstant.notFound
+#  ------ -----------------------------------------------------------------------
+#
+#      - name: "Run PHPStan"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s phpstan"
+
+  testsuite:
+    name: all tests with core v14
+    runs-on: ubuntu-22.04
+    needs: code-quality
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '8.2', '8.5' ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Prepare dependencies for TYPO3 v14"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s lintPhp"
+
+      - name: "Unit"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s unit"
+
+# @todo Functional tests disabled for now due to TCA auto-migration deprecations.
+#      - name: "Functional SQLite"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s functional -d sqlite"
+#
+#      - name: "Functional MariaDB 10.5 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+#
+#      - name: "Functional MariaDB 10.5 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+#
+#      - name: "Functional MySQL 8.0 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+#
+#      - name: "Functional MySQL 8.0 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+#
+#      - name: "Functional PostgresSQL 10"
+#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -155,6 +155,7 @@ Options:
             - clean: clean up build and testing related files
             - composer: "composer" with all remaining arguments dispatched.
             - composerUpdate: "composer update", handy if host has no PHP
+            - downloadGerritPatch: Download TYPO3 Gerrit change and transform it to composer patch files in "patches/"
             - functional: functional tests
             - lintPhp: PHP linting
             - lintTypoScript: TypoScript linting
@@ -216,10 +217,11 @@ Options:
             - 15    maintained until 2027-11-11
             - 16    maintained until 2028-11-09
 
-    -t <13>
+    -t <13|14>
         Only with -s composerInstall|composerInstallMin|composerInstallMax
         Specifies the TYPO3 CORE Version to be used
             - 13: (default) use TYPO3 v13
+            - 14: use TYPO3 v14 (~14.2.0@dev)
 
     -p <8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
@@ -339,7 +341,7 @@ while getopts "a:b:s:d:i:p:t:xy:o:nhu" OPT; do
             ;;
         t)
             CORE_VERSION=${OPTARG}
-            if ! [[ ${CORE_VERSION} =~ ^(13)$ ]]; then
+            if ! [[ ${CORE_VERSION} =~ ^(13|14)$ ]]; then
                 INVALID_OPTIONS+=("t ${OPTARG}")
             fi
             ;;
@@ -517,6 +519,11 @@ case ${TEST_SUITE} in
         # restore composer json
         cp -Rf composer.json.orig composer.json
         ;;
+    downloadGerritPatch)
+        COMMAND=(php -dxdebug.mode=off Build/Scripts/download-patch-from-gerrit.phpsh "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-${SUFFIX} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+      ;;
     functional)
         PHPUNIT_CONFIG_FILE="Build/phpunit/FunctionalTests.xml"
         COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} "$@")

--- a/Build/phpstan/Core14/phpstan-baseline.neon
+++ b/Build/phpstan/Core14/phpstan-baseline.neon
@@ -1,0 +1,11 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\RequestInterface\\:\\:getQueryParams\\(\\)\\.$#"
+			count: 1
+			path: ../../../Classes/EventListener/GlossaryModuleShouldNotRenderDeepLTranslationDropdown.php
+
+		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/AbstractDeepLTestCase.php

--- a/Build/phpstan/Core14/phpstan.neon
+++ b/Build/phpstan/Core14/phpstan.neon
@@ -1,0 +1,25 @@
+includes:
+  - ../../../.Build/vendor/saschaegerer/phpstan-typo3/extension.neon
+  - phpstan-baseline.neon
+
+parameters:
+  # Use local .cache dir instead of /tmp
+  tmpDir: ../../../.cache/phpstan
+
+  level: 8
+
+  paths:
+    - ../../../Classes/
+    - ../../../Tests/
+
+  excludePaths:
+    - ../../../.Build/*
+    - ../../../Tests/Functional/Fixtures/Extensions/test_migration/ext_emconf.php
+    - ../../../Tests/Functional/Fixtures/Extensions/test_migration_deleted/ext_emconf.php
+    - ../../../Tests/Functional/Fixtures/Extensions/test_services_override/ext_emconf.php
+
+  typo3:
+    contextApiGetAspectMapping:
+      'frontend.preview': TYPO3\CMS\Frontend\Aspect\PreviewAspect
+    requestGetAttributeMapping:
+      'typo3.testing.context': TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -35,6 +35,29 @@
         (new \SBUERK\AvailableFixturePackages())->adoptFixtureExtensions();
     }
 
+    /**
+     * @todo Fix testing-framework extension package information loading within the framework and remove workaround
+     *       here after upgrade to testing-framework release containing the fix.
+     */
+    $frameworkExtension = [
+        'Resources/Core/Functional/Extensions/json_response',
+        'Resources/Core/Functional/Extensions/private_container',
+    ];
+    $composerPackageManager = new \TYPO3\TestingFramework\Composer\ComposerPackageManager();
+    $testingFrameworkPath = $composerPackageManager->getPackageInfo('typo3/testing-framework')->getRealPath();
+    foreach ($frameworkExtension as $frameworkExtensionPath) {
+        $packageInfo = $composerPackageManager->getPackageInfoWithFallback(rtrim($testingFrameworkPath, '/') . '/' . $frameworkExtensionPath);
+        if ($packageInfo === null) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Could not preload "typo3/testing-framework" extension "%s".',
+                    basename($frameworkExtensionPath),
+                ),
+                1734217315,
+            );
+        }
+    }
+
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
     $testbase->defineOriginalRootPath();
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');

--- a/Tests/Functional/Fixtures/Extensions/test_migration/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_migration/composer.json
@@ -5,12 +5,16 @@
 	"license": ["GPL-2.0-or-later"],
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "test_migration"
+			"extension-key": "test_migration",
+			"Package": {
+				"providesPackages": []
+			}
 		}
 	},
 	"require": {
 		"typo3/cms-core": "*",
 		"web-vision/deepltranslate-core": "*",
 		"web-vision/deepltranslate-glossary": "*"
-	}
+	},
+	"version": "1.0.0"
 }

--- a/Tests/Functional/Fixtures/Extensions/test_migration_deleted/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_migration_deleted/composer.json
@@ -5,12 +5,16 @@
 	"license": ["GPL-2.0-or-later"],
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "test_migration_deleted"
+			"extension-key": "test_migration_deleted",
+			"Package": {
+				"providesPackages": []
+			}
 		}
 	},
 	"require": {
 		"typo3/cms-core": "*",
 		"web-vision/deepltranslate-core": "*",
 		"web-vision/deepltranslate-glossary": "*"
-	}
+	},
+	"version": "1.0.0"
 }

--- a/Tests/Functional/Fixtures/Extensions/test_services_override/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_services_override/composer.json
@@ -5,11 +5,15 @@
 	"license": ["GPL-2.0-or-later"],
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "test_services_override"
+			"extension-key": "test_services_override",
+			"Package": {
+				"providesPackages": []
+			}
 		}
 	},
 	"require": {
 		"typo3/cms-core": "*",
 		"web-vision/deepltranslate-core": "*"
-	}
+	},
+	"version": "1.0.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
 		"php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
 		"ext-curl": "*",
 		"ext-json": "*",
-		"typo3/cms-backend": "^13.4.27",
-		"typo3/cms-core": "^13.4.27",
+		"typo3/cms-backend": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-core": "^13.4.27 || ~14.2.0@dev",
 		"web-vision/deepltranslate-core": "~6.0.0@dev"
 	},
 	"require-dev": {
@@ -59,16 +59,18 @@
 		"ramsey/uuid": "^4.7",
 		"saschaegerer/phpstan-typo3": "2.1.1 || ^3.0.1",
 		"sbuerk/fixture-packages": "^1.1.3",
+		"sbuerk/typo3-gerrit-change-downloader": "~0.0.2",
 		"sbuerk/typo3-site-based-test-trait": "^2.0.1 || ^3.0.0",
-		"typo3/cms-belog": "^13.4.27",
-		"typo3/cms-install": "^13.4.27",
-		"typo3/cms-lowlevel": "^13.4.27",
-		"typo3/cms-rte-ckeditor": "^13.4.27",
-		"typo3/cms-scheduler": "^13.4.27",
-		"typo3/cms-setup": "^13.4.27",
-		"typo3/cms-tstemplate": "^13.4.27",
-		"typo3/cms-workspaces": "^13.4.27",
+		"typo3/cms-belog": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-install": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-lowlevel": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-rte-ckeditor": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-scheduler": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-setup": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-tstemplate": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-workspaces": "^13.4.27 || ~14.2.0@dev",
 		"typo3/testing-framework": "^9.5.0",
+		"vaimo/composer-patches": "^6.0.1",
 		"web-vision/deepl-base": "~2.0.0@dev"
 	},
 	"suggest": {
@@ -89,7 +91,9 @@
 			"php-http/discovery": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true,
-			"sbuerk/fixture-packages": true
+			"sbuerk/fixture-packages": true,
+			"vaimo/composer-patches": true,
+			"sbuerk/typo3-gerrit-change-downloader": true
 		},
 		"bin-dir": ".Build/bin",
 		"optimize-autoloader": true,
@@ -101,7 +105,11 @@
 		"typo3/cms": {
 			"app-dir": ".Build",
 			"extension-key": "deepltranslate_glossary",
-			"web-dir": ".Build/Web"
+			"web-dir": ".Build/Web",
+			"version": "6.0.0-dev",
+			"Package": {
+				"providesPackages": []
+			}
 		},
 		"sbuerk/fixture-packages": {
 			"paths": {
@@ -112,6 +120,8 @@
 		},
 		"branch-alias": {
 			"dev-main": "6.0.x-dev"
-		}
-	}
+		},
+		"patches-search": "patches/"
+	},
+	"prefer-stable": true
 }

--- a/patches/typo3-cms-backend_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+++ b/patches/typo3-cms-backend_93484_bugfix-strip-title-from-package-description-if-extracted.patch
@@ -1,0 +1,43 @@
+@package typo3/cms-backend
+@label [BUGFIX] Strip title from package description if extracted
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+@version ~14.2.0
+
+From 17f8256acba6eb1c5b4b3e2732b63dc891279ad0 Mon Sep 17 00:00:00 2001
+From: Benjamin Kott <benjamin.kott@outlook.com>
+Date: Tue, 31 Mar 2026 11:24:01 +0200
+Subject: [PATCH] [BUGFIX] Strip title from package description if extracted
+
+When a composer description contains " - ", the part before
+the separator is used as the package title. However, the
+description was not updated and still contained the full
+string including the title prefix, leading to duplicate
+information when both title and description are displayed.
+
+The description is now set to only the part after the
+separator when a title is extracted.
+
+Resolves: #109435
+Releases: main
+Change-Id: I2a7a57ca18b750fa26fc967fe3cc5f6df07f3728
+Reviewed-on: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+Reviewed-by: Benjamin Franzke <ben@bnf.dev>
+Reviewed-by: Benni Mack <benni@typo3.org>
+Tested-by: Benjamin Franzke <ben@bnf.dev>
+Tested-by: Benni Mack <benni@typo3.org>
+Tested-by: core-ci <typo3@b13.com>
+---
+
+diff --git a/Classes/Controller/AboutController.php b/Classes/Controller/AboutController.php
+index 7ffdf16..c8ca11c 100644
+--- a/Classes/Controller/AboutController.php
++++ b/Classes/Controller/AboutController.php
+@@ -81,7 +81,7 @@
+             }
+             $extensions[] = [
+                 'key' => $package->getPackageKey(),
+-                'title' => $package->getPackageMetaData()->getDescription(),
++                'title' => $package->getPackageMetaData()->getTitle(),
+                 'authors' => $package->getValueFromComposerManifest('authors'),
+             ];
+         }

--- a/patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+++ b/patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
@@ -1,0 +1,53 @@
+@package typo3/cms-core
+@label [BUGFIX] Strip title from package description if extracted
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+@version ~14.2.0
+@after typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
+
+From 17f8256acba6eb1c5b4b3e2732b63dc891279ad0 Mon Sep 17 00:00:00 2001
+From: Benjamin Kott <benjamin.kott@outlook.com>
+Date: Tue, 31 Mar 2026 11:24:01 +0200
+Subject: [PATCH] [BUGFIX] Strip title from package description if extracted
+
+When a composer description contains " - ", the part before
+the separator is used as the package title. However, the
+description was not updated and still contained the full
+string including the title prefix, leading to duplicate
+information when both title and description are displayed.
+
+The description is now set to only the part after the
+separator when a title is extracted.
+
+Resolves: #109435
+Releases: main
+Change-Id: I2a7a57ca18b750fa26fc967fe3cc5f6df07f3728
+Reviewed-on: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+Reviewed-by: Benjamin Franzke <ben@bnf.dev>
+Reviewed-by: Benni Mack <benni@typo3.org>
+Tested-by: Benjamin Franzke <ben@bnf.dev>
+Tested-by: Benni Mack <benni@typo3.org>
+Tested-by: core-ci <typo3@b13.com>
+---
+
+diff --git a/Classes/Package/Package.php b/Classes/Package/Package.php
+index b163b85..383c126 100644
+--- a/Classes/Package/Package.php
++++ b/Classes/Package/Package.php
+@@ -143,13 +143,15 @@
+     {
+         $this->packageMetaData = new MetaData($this->getPackageKey());
+         $description = (string)$this->getValueFromComposerManifest('description');
+-        $this->packageMetaData->setDescription($description);
+         $descriptionParts = explode(' - ', $description, 2);
+-        $title = $description;
+         if (count($descriptionParts) === 2) {
+             $title = $descriptionParts[0];
++            $description = $descriptionParts[1];
++        } else {
++            $title = $description;
+         }
+         $this->packageMetaData->setTitle($title);
++        $this->packageMetaData->setDescription($description);
+         $this->packageMetaData->setPackageType((string)$this->getValueFromComposerManifest('type'));
+         $isFrameworkPackage = $this->packageMetaData->isFrameworkType();
+         $version = (string)($this->getValueFromComposerManifest('version') ?? '1.0.0');

--- a/patches/typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
+++ b/patches/typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
@@ -1,0 +1,61 @@
+@package typo3/cms-core
+@label [BUGFIX] Avoid `Undefined property: stdClass::$version` warning
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93530
+@version ~14.2.0
+
+From 0672a9436796d0b8cc047fe29e611a654dbea6e7 Mon Sep 17 00:00:00 2001
+From: Stefan Bürk <stefan@buerk.tech>
+Date: Thu, 02 Apr 2026 16:34:35 +0200
+Subject: [PATCH] [BUGFIX] Avoid `Undefined property: stdClass::$version` warning
+
+With [1] resolving #108345 #96388 extension need to have
+`version` set in the extension `composer.json` for classic
+mode installation.
+
+In case the optional `version` key is not set, which is
+recommended to avoid by composer, this leads to a native
+php warning:
+
+  Undefined property: stdClass::$version in
+  vendor/typo3/cms-core/Classes/Package/PackageManager.php:939
+
+This has been detected trying to make a extension TYPO3 v14 ready
+with v13/v14 dual support and keeping the `ext_emconf.php`, which
+emits the warning during functional test execution and should at
+least respect that it is optional and possible not available.
+
+Does not fix the fact that the deprecation is still triggered,
+which is the topic of another change to discuss and resolve.
+
+Let's make at least the warning to vanish.
+
+[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/91908
+
+Resolves: #109473
+Related: #108345
+Related: #96388
+Releases: main
+Change-Id: Iac794747b3afe837a7b89e369233fd9f891aa714
+Reviewed-on: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93530
+Tested-by: Oliver Klee <typo3-coding@oliverklee.de>
+Tested-by: Garvin Hicking <garvin@hick.ing>
+Reviewed-by: Garvin Hicking <garvin@hick.ing>
+Tested-by: Stefan Bürk <stefan@buerk.tech>
+Reviewed-by: Stefan Bürk <stefan@buerk.tech>
+Tested-by: core-ci <typo3@b13.com>
+Reviewed-by: Oliver Klee <typo3-coding@oliverklee.de>
+---
+
+diff --git a/Classes/Package/PackageManager.php b/Classes/Package/PackageManager.php
+index 3d9496a..dd9b427 100644
+--- a/Classes/Package/PackageManager.php
++++ b/Classes/Package/PackageManager.php
+@@ -936,7 +936,7 @@
+     private function isComposerOnlyCapable(\stdClass $manifest): bool
+     {
+         return isset($manifest->extra->{'typo3/cms'}->Package->providesPackages)
+-            && $manifest->version !== null;
++            && ($manifest->version ?? null) !== null;
+     }
+
+     /**

--- a/patches/typo3-cms-core_93536_task-allow-extension-version-declaration-in-extra.version.patch
+++ b/patches/typo3-cms-core_93536_task-allow-extension-version-declaration-in-extra.version.patch
@@ -1,0 +1,339 @@
+@package typo3/cms-core
+@label [TASK] Allow extension version declaration in extra.version
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93536
+@version ~14.2.0
+@after typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+
+From ccce176b8173fbb59d79312a0723b599e8838682 Mon Sep 17 00:00:00 2001
+From: Helmut Hummel <typo3@helhum.io>
+Date: Fri, 03 Apr 2026 12:08:32 +0200
+Subject: [PATCH] [TASK] Allow extension version declaration in extra.version
+
+Using the top level "version" field for a TYPO3 extension version
+for classic mode has the disadvantage, that Composer pulls in
+this version also for branches (aka. dev versions).
+This would then either mean for extension authors that they need
+to update this field constantly for branches and/ or releases,
+which would have a bigger impact on behaviour in Composer managed
+TYPO3 systems and extension authors than initially intended.
+
+Therefore it is now possible to declare the version in extra section.
+
+This field must still match the composer version that is tagged.
+
+Releases: main
+Resolves: #109482
+Change-Id: I96cbdb175dc46ff5b3b1f863663412395fd4469c
+Reviewed-on: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93536
+Reviewed-by: Garvin Hicking <garvin@hick.ing>
+Reviewed-by: Georg Ringer <georg.ringer@gmail.com>
+Tested-by: Garvin Hicking <garvin@hick.ing>
+Reviewed-by: Stefan Bürk <stefan@buerk.tech>
+Tested-by: Georg Ringer <georg.ringer@gmail.com>
+Tested-by: core-ci <typo3@b13.com>
+Tested-by: Stefan Bürk <stefan@buerk.tech>
+---
+
+diff --git a/Classes/Package/Package.php b/Classes/Package/Package.php
+index 383c126..85739b7 100644
+--- a/Classes/Package/Package.php
++++ b/Classes/Package/Package.php
+@@ -150,16 +150,17 @@
+         } else {
+             $title = $description;
+         }
++        $manifest = $this->getValueFromComposerManifest();
+         $this->packageMetaData->setTitle($title);
+         $this->packageMetaData->setDescription($description);
+-        $this->packageMetaData->setPackageType((string)$this->getValueFromComposerManifest('type'));
++        $this->packageMetaData->setPackageType($manifest->type ?? '');
+         $isFrameworkPackage = $this->packageMetaData->isFrameworkType();
+-        $version = (string)($this->getValueFromComposerManifest('version') ?? '1.0.0');
++        $version = $manifest->extra->{'typo3/cms'}->{'version'} ?? $manifest->version ?? '1.0.0+no-version-set';
+         if ($isFrameworkPackage) {
+             $version = str_replace('-dev', '', (new Typo3Version())->getVersion());
+         }
+         $this->packageMetaData->setVersion($version);
+-        $requirements = $this->getValueFromComposerManifest('require');
++        $requirements = $manifest->require ?? null;
+         if ($requirements !== null) {
+             foreach ($requirements as $packageName => $versionConstraints) {
+                 if ($this->ignoreDependencyInPackageConstraint($packageName, $packageManager, $isBuildingPackageArtifact)) {
+@@ -174,7 +175,7 @@
+                 );
+             }
+         }
+-        $suggestions = $this->getValueFromComposerManifest('suggest');
++        $suggestions = $manifest->suggest ?? null;
+         if ($suggestions !== null) {
+             foreach ($suggestions as $packageName => $description) {
+                 if ($this->ignoreDependencyInPackageConstraint($packageName, $packageManager, $isBuildingPackageArtifact)) {
+@@ -184,7 +185,7 @@
+                 $this->packageMetaData->addConstraint($constraint);
+             }
+         }
+-        $conflicts = $this->getValueFromComposerManifest('conflict');
++        $conflicts = $manifest->conflict ?? null;
+         if ($conflicts !== null) {
+             foreach ($conflicts as $packageName => $versionConstraints) {
+                 if ($this->ignoreDependencyInPackageConstraint($packageName, $packageManager, $isBuildingPackageArtifact)) {
+diff --git a/Classes/Package/PackageManager.php b/Classes/Package/PackageManager.php
+index dd9b427..cc419ff 100644
+--- a/Classes/Package/PackageManager.php
++++ b/Classes/Package/PackageManager.php
+@@ -936,7 +936,10 @@
+     private function isComposerOnlyCapable(\stdClass $manifest): bool
+     {
+         return isset($manifest->extra->{'typo3/cms'}->Package->providesPackages)
+-            && ($manifest->version ?? null) !== null;
++            && (
++                ($manifest->version ?? null) !== null
++                || isset($manifest->extra->{'typo3/cms'}->version)
++            );
+     }
+
+     /**
+diff --git a/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst b/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst
+index cea425f..7ca1e9b 100644
+--- a/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst
++++ b/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst
+@@ -26,7 +26,6 @@
+         "name": "vendor/example",
+         "type": "typo3-cms-extension",
+         "description": "example",
+-        "version": "1.0.0",
+         "license": "GPL-2.0-or-later",
+         "require": {
+             "typo3/cms-core": "^14.2",
+@@ -36,6 +35,7 @@
+         "extra": {
+             "typo3/cms": {
+                 "extension-key": "example_extension",
++                "version": "1.0.0",
+                 "Package": {
+                     "providesPackages": {
+                         "symfony/dotenv": ""
+@@ -52,7 +52,6 @@
+         "name": "vendor/example2",
+         "type": "typo3-cms-extension",
+         "description": "example",
+-        "version": "1.0.0",
+         "license": "GPL-2.0-or-later",
+         "require": {
+             "typo3/cms-core": "^14.2"
+@@ -60,6 +59,7 @@
+         "extra": {
+             "typo3/cms": {
+                 "extension-key": "example2_extension",
++                "version": "1.0.0",
+                 "Package": {
+                     "providesPackages": {}
+                 }
+@@ -68,10 +68,20 @@
+     }
+
+ For compatibility with TYPO3 classic mode, third-party extensions
+-must set the exact extension version in the top-level `"version"` field
+-of `composer.json`. This version should match the version previously
++must set the exact extension version in `extra.typo3/cms.version`
++or in the top level `version` field of `composer.json`.
++This version must match the version previously
+ defined in `ext_emconf.php` and the released Git tag.
+
++Fixture extensions used in tests can set any version number, for example `1.0.0`,
++but a version number must still be provided to avoid deprecation messages.
++
++During testing, the version number is not evaluated.
++
++TYPO3 Core extensions may omit the version number
++in `composer.json`, because their version can and will be derived from
++php`\TYPO3\CMS\Core\Information\Typo3Version`.
++
+ If an extension depends on regular Composer packages, these packages
+ must be declared in
+ `extra.typo3/cms.Package.providesPackages`.
+@@ -81,6 +91,13 @@
+ to avoid deprecation messages and to declare future compatibility
+ with TYPO3 classic mode.
+
++If strict `composer.json` validation is required and the extension is published
++to Packagist as well, where setting the top level `version` field is not recommended,
++it is recommended to set the version via `extra.typo3/cms.version`.
++
++If the `version` field is set anyway, it is recommended to omit `extra.typo3/cms.version`
++to avoid redundant data points.
++
+ Impact
+ ======
+
+@@ -88,7 +105,8 @@
+
+ TYPO3 classic installations will trigger a deprecation message
+ for extensions that still ship `ext_emconf.php` but do not yet define
+-both the `"version"` field and `providesPackages` in `composer.json`.
++both `extra.typo3/cms.version` (or `"version"` field ) *and* `providesPackages`
++in `composer.json`.
+
+ Affected installations
+ ======================
+@@ -109,6 +127,6 @@
+ For the time being, `ext_emconf.php` may still need to be kept for
+ third-party tooling such as TYPO3 TER or Tailor. However, once the
+ required metadata is correctly defined in `composer.json`,
+-TYPO3 will no longer need to evaluate `ext_emconf.php`.
++TYPO3 will no longer evaluate `ext_emconf.php`.
+
+ .. index:: ext:core, NotScanned
+diff --git a/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst b/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst
+index 9a05b80..ef8c299 100644
+--- a/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst
++++ b/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst
+@@ -18,7 +18,7 @@
+
+ This is now resolved by allowing an extension's `composer.json`
+ to contain information that previously had to be defined in
+-`ext_emconf.php`.
++`ext_emconf.php`:
+
+ 1. Extension title
+ 2. Extension version
+@@ -30,16 +30,15 @@
+ See :ref:`feature-108653-1767199420` for how the extension title can also be set
+ in `composer.json`.
+
+-The version number can be set in the regular `"version"` field
+-in `composer.json`.
+-
+ Extension version
+ -----------------
+
++The version number can be set in `extra.typo3/cms.version` or alternatively
++in the regular `"version"` field in `composer.json`.
++
+ For third-party extensions to be compatible with TYPO3 classic mode,
+-this field must now be set to the exact version previously defined in `ext_emconf.php`
+-and must match the version in the Git tag
+-(for example, when publishing to Packagist).
++this version must now be set to the exact version previously defined in `ext_emconf.php`
++and must match the version in the Git tag (for example, when publishing to Packagist).
+
+ Fixture extensions used in tests can set any version number, for example `1.0.0`,
+ but a version number must still be provided to avoid deprecation messages.
+@@ -57,7 +56,7 @@
+ a version range.
+
+ `composer.json` also contains a field for specifying dependencies
+-by using a Composer package name with a version range.
++using a Composer package name with a version range.
+ However, there is no direct way to distinguish whether such a package name
+ refers to another TYPO3 extension or to a regular Composer package
+ that should be installed from Packagist.
+@@ -113,7 +112,6 @@
+         "name": "vendor/example",
+         "type": "typo3-cms-extension",
+         "description": "example",
+-        "version": "1.0.0",
+         "license": "GPL-2.0-or-later",
+         "require": {
+             "typo3/cms-core": "^14.2",
+@@ -123,6 +121,7 @@
+         "extra": {
+             "typo3/cms": {
+                 "extension-key": "example_extension",
++                "version": "1.0.0",
+                 "Package": {
+                     "providesPackages": {
+                         "symfony/dotenv": ""
+@@ -151,7 +150,6 @@
+         "name": "vendor/example",
+         "type": "typo3-cms-extension",
+         "description": "example",
+-        "version": "1.0.0",
+         "license": "GPL-2.0-or-later",
+         "require": {
+             "typo3/cms-core": "^14.2",
+@@ -160,6 +158,7 @@
+         "extra": {
+             "typo3/cms": {
+                 "extension-key": "example_extension",
++                "version": "1.0.0",
+                 "Package": {
+                     "providesPackages": {}
+                 }
+@@ -167,13 +166,41 @@
+         }
+     }
+
++If the `version` field is set anyway, the version is populated from there
++and `extra.typo3/cms.version` can be omitted:
++
++..  code-block:: json
++
++    {
++        "name": "vendor/example",
++        "version": "1.0.0",
++        "type": "typo3-cms-extension",
++        "description": "example",
++        "license": "GPL-2.0-or-later",
++        "require": {
++            "typo3/cms-core": "^14.2",
++            "vendor/other-example": "*",
++            "symfony/dotenv": "^8.0"
++        },
++        "extra": {
++            "typo3/cms": {
++                "extension-key": "example_extension",
++                "Package": {
++                    "providesPackages": {
++                        "symfony/dotenv": ""
++                    }
++                }
++            }
++        }
++    }
++
+ Be aware that keeping `ext_emconf.php`, while no longer directly required
+ by TYPO3, may still be necessary for some tools,
+ such as Tailor or TYPO3 TER. Therefore, for the time being, it is recommended
+ to keep the file and ensure that its information stays in sync
+ with `composer.json` as outlined above.
+
+-However, TYPO3 will **not** evaluate `ext_emconf.php` any more if the `version` field
++However, TYPO3 will **not** evaluate `ext_emconf.php` anymore if the `version` field
+ and `providesPackages` are correctly defined in `composer.json`.
+
+ Impact
+@@ -181,7 +208,7 @@
+
+ Extensions can now omit `ext_emconf.php` in TYPO3 classic mode.
+ A deprecation message is shown during cache warm-up when `ext_emconf.php`
+-is present and `composer.json` is not yet future-proof,
++is present and `composer.json` is not yet future-proof
+ because it does not contain the `version` and `providesPackages` definitions.
+
+ .. index:: ext:core
+diff --git a/Tests/Unit/Utility/Fixtures/ext_emconf.php b/Tests/Unit/Utility/Fixtures/ext_emconf.php
+deleted file mode 100644
+index 8288584..0000000
+--- a/Tests/Unit/Utility/Fixtures/ext_emconf.php
++++ /dev/null
+@@ -1,19 +0,0 @@
+-<?php
+-
+-declare(strict_types=1);
+-
+-$EM_CONF[$_EXTKEY] = [
+-    'title' => '',
+-    'description' => 'This is a fixture extension configuration file used for unit tests.',
+-    'category' => '',
+-    'state' => 'stable',
+-    'author' => '',
+-    'author_email' => '',
+-    'author_company' => '',
+-    'version' => '14.3.0',
+-    'constraints' => [
+-        'depends' => [],
+-        'conflicts' => [],
+-        'suggests' => [],
+-    ],
+-];


### PR DESCRIPTION
> [!IMPORTANT]
> This does not mark the official support for now, this
> is only done to start the testing and development for
> TYPO3 v14.
>
> Can be tested and issues reported using the GitHub
> issue tracker.

This change allows now using this extension with current
TYPO3 v14.2 feature freeze version, which is done adding
the corresponding composer constraints, required adoption
for composer.json to mitigate `ext_emconf.php` deprecation
and test it in a instance. [1]

"vaimo/composer-patches" && "sbuerk/typo3-gerrit-change-downloader"
are added as development dependencies along with a couple
of core patches required to allow functional testing with
"TYPO3 14.2.0@dev". [2]

Additionally, extension title and description is provided
combined as package description in `composer.json` adopted
from `ext_emconf.php`. [3]

GitHub publish action is modified to ensure setting the
version as extra key based on the tag just to be sure.

`Build/Scripts/runTests.sh` is modified to allow providing
`-t 14` to select TYPO3 v14 version for suits (tools).

GitHub action pipelines for TYPO3 v14 are also added except
functional tests due to TCA migration for TYPO3 v14 which
needs to be mitigated as a dedicated change and one of the
first issues to tackle.

Same for TYPO3 v14 phpstan finding deprecated enumaration
class usage and not yet migrated to native PHP enum, which
is also a task for a dedicated follow-up change.

Used command(s):

```bash
composer config \
  extra.typo3/cms.version "6.0.0-dev" \
&& composer config \
  "allow-plugins"."vaimo/composer-patches" true \
&& composer config \
  "allow-plugins"."sbuerk/typo3-gerrit-change-downloader" true \
&& composer config \
  "extra"."patches-search" "patches/" \
&& composer config \
  "extra"."typo3/cms"."Package" '{}' \
&& composer config \
  --json "extra"."typo3/cms"."Package" '{"providesPackages": {}}' \
&& composer config \
  -d Tests/Functional/Fixtures/Extensions/test_migration \
  --json "extra"."typo3/cms"."Package" '{"providesPackages": {}}' \
&& composer config \
  -d Tests/Functional/Fixtures/Extensions/test_migration \
  version "1.0.0" \
&& composer config \
  -d Tests/Functional/Fixtures/Extensions/test_migration_deleted \
  --json "extra"."typo3/cms"."Package" '{"providesPackages": {}}' \
&& composer config \
  -d Tests/Functional/Fixtures/Extensions/test_migration_deleted \
  version "1.0.0" \
&& composer config \
  -d Tests/Functional/Fixtures/Extensions/test_services_override \
  --json "extra"."typo3/cms"."Package" '{"providesPackages": {}}' \
&& composer config \
  -d Tests/Functional/Fixtures/Extensions/test_services_override \
  version "1.0.0" \
&& composer require --dev --no-update \
    "vaimo/composer-patches":"^6.0.1" \
    "sbuerk/typo3-gerrit-change-downloader":"~0.0.2" \
    "typo3/cms-belog":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-install":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-lowlevel":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-rte-ckeditor":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-scheduler":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-setup":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-tstemplate":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-workspaces":"^13.4.27 || ~14.2.0@dev" \
&& composer require --no-update \
    "typo3/cms-backend":"^13.4.27 || ~14.2.0@dev" \
    "typo3/cms-core":"^13.4.27 || ~14.2.0@dev" \
&& composer install \
&& Build/Scripts/runTests.sh -s downloadGerritPatch 93530 \
&& Build/Scripts/runTests.sh -s downloadGerritPatch 93484 \
&& Build/Scripts/runTests.sh -s downloadGerritPatch 93536
```

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.html#feature-108345-allow-extensions-without-ext-emconf-php-in-classic-mode
[2] https://review.typo3.org/c/Packages/TYPO3.CMS/+/93596
[3] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108304-PopulateExtensionTitleFromComposerJson.html#breaking-108304-populate-extension-title-from-composer-json
