### PR TITLE
[TASK] DPL-158: Replace deprecated `Icon::SIZE_* string constants`

### DIFF
--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -40,17 +40,8 @@ jobs:
       - name: "Find duplicate exception codes"
         run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
-# @todo Disabled due to following finding with `-t 14 -s phpstan`:
-#
-#  ------ -----------------------------------------------------------------------
-#  Line   Classes/EventListener/GlossarySyncButtonProvider.php
-#  ------ -----------------------------------------------------------------------
-#  85     Access to undefined constant TYPO3\CMS\Core\Imaging\Icon::SIZE_SMALL.
-#  🪪  classConstant.notFound
-#  ------ -----------------------------------------------------------------------
-#
-#      - name: "Run PHPStan"
-#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s phpstan"
+      - name: "Run PHPStan"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s phpstan"
 
   testsuite:
     name: all tests with core v14

--- a/Classes/EventListener/GlossarySyncButtonProvider.php
+++ b/Classes/EventListener/GlossarySyncButtonProvider.php
@@ -13,8 +13,8 @@ use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
@@ -82,7 +82,7 @@ final class GlossarySyncButtonProvider
         $button = $event->getButtonBar()->makeLinkButton();
         $button->setIcon($iconFactory->getIcon(
             'apps-pagetree-folder-contains-glossary',
-            Icon::SIZE_SMALL
+            IconSize::SMALL,
         ));
         $button->setTitle($title);
         $button->setShowLabelText(true);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "web-vision/deepltranslate-glossary",
-	"description": "DeepL Translate Add-On providing glossary functionality within TYPO3 CMS",
+	"description": "DeepL Translate: Glossary - Add-on providing glossary functionality",
 	"license": [
 		"GPL-2.0-or-later"
 	],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'DeepL Translate: Glossary',
-    'description' => 'DeepL Translate Add-On providing glossary functionality',
+    'description' => 'Add-on providing glossary functionality',
     'category' => 'backend',
     'author' => 'web-vision GmbH Team',
     'author_company' => 'web-vision GmbH',


### PR DESCRIPTION
TYPO3 v13.0 deprecated Icon::SIZE_* string constants`[1] in favour of the
new `\TYPO3\CMS\Core\Imaging\IconSize` [2] and aligning some methods. All
class constant usages are replaced with the enum for both supported TYPO3
versions now.

This allows us to enable static code analyzer (PHPStan) for TYPO3 v14.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101475-IconSizeStringConstants.html#deprecation-101475-icon-size-string-constants
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Feature-101475-IconSizeEnum.html#feature-101475-iconsizeenum
