### PR TITLE
[TASK] DPL-158: Hard require `typo3/cms-install`

### DIFF
--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -244,6 +244,7 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
         $fh = fopen($filepath, 'r');
         $size = filesize($filepath);
         $content = '';
+        /** @phpstan-ignore notIdentical.alwaysTrue */
         if ($fh !== false && $size !== false) {
             $content = fread($fh, $size);
             fclose($fh);

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
 		"ext-json": "*",
 		"typo3/cms-backend": "^13.4.27 || ~14.2.0@dev",
 		"typo3/cms-core": "^13.4.27 || ~14.2.0@dev",
+		"typo3/cms-install": "13.4.*@dev || 14.2.*@dev",
 		"web-vision/deepltranslate-core": "~6.0.0@dev"
 	},
 	"require-dev": {
@@ -62,7 +63,6 @@
 		"sbuerk/typo3-gerrit-change-downloader": "~0.0.2",
 		"sbuerk/typo3-site-based-test-trait": "^2.0.1 || ^3.0.0",
 		"typo3/cms-belog": "^13.4.27 || ~14.2.0@dev",
-		"typo3/cms-install": "^13.4.27 || ~14.2.0@dev",
 		"typo3/cms-lowlevel": "^13.4.27 || ~14.2.0@dev",
 		"typo3/cms-rte-ckeditor": "^13.4.27 || ~14.2.0@dev",
 		"typo3/cms-scheduler": "^13.4.27 || ~14.2.0@dev",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,6 +15,7 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '13.4.27-13.4.99',
             'backend' => '13.4.27-13.4.99',
             'setup' => '13.4.27-13.4.99',
+            'install' => '13.4.27-13.4.99',
             'deepltranslate_core' => '6.0.0-6.0.99',
         ],
         'conflicts' => [


### PR DESCRIPTION
TYPO3 v13 declared `EXT:install` optional for composer
mode installations, which is technically not completly
correct.

In case a extension provides one or more `UpgradeWizards`
this fails building the dependency injection container
with a hard exception and leads to a broken setup.

With TYPO3 v14 the interfaces along with related classes
and services like the `upgrade:*` commands has been
moved with a couple of changes to `EXT:core` and have
old intercaces as compat layer on board making system
extension `EXT:install` optional.

Enforced by the dual TYPO3 version to provide we add
the `EXT:install` requirement as hard requirement to
ensure that installing `EXT:deepltranslate_glossary`
does not lead to a broken setup anymore.

Used command(s):

```bash
composer require --no-update \
  "typo3/cms-install":"13.4.*@dev || 14.2.*@dev"
```
