### PR TITLE
[TASK] DPL-158: Display `sync` button in `Records` module (v14)

### DIFF
--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,11 +1,19 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\RequestInterface\\:\\:getQueryParams\\(\\)\\.$#"
+			message: '#^Call to an undefined method Psr\\Http\\Message\\RequestInterface\:\:getQueryParams\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: ../../../Classes/EventListener/GlossaryModuleShouldNotRenderDeepLTranslationDropdown.php
 
 		-
-			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			message: '#^Call to function method_exists\(\) with TYPO3\\CMS\\Backend\\Template\\Components\\ModifyButtonBarEvent and ''getRequest'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: ../../../Classes/EventListener/GlossarySyncButtonProvider.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ../../../Tests/Functional/AbstractDeepLTestCase.php

--- a/Build/phpstan/Core14/phpstan-baseline.neon
+++ b/Build/phpstan/Core14/phpstan-baseline.neon
@@ -1,11 +1,19 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\RequestInterface\\:\\:getQueryParams\\(\\)\\.$#"
+			message: '#^Call to an undefined method Psr\\Http\\Message\\RequestInterface\:\:getQueryParams\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: ../../../Classes/EventListener/GlossaryModuleShouldNotRenderDeepLTranslationDropdown.php
 
 		-
-			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			message: '#^Call to function method_exists\(\) with TYPO3\\CMS\\Backend\\Template\\Components\\ModifyButtonBarEvent and ''getRequest'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../Classes/EventListener/GlossarySyncButtonProvider.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ../../../Tests/Functional/AbstractDeepLTestCase.php

--- a/Classes/EventListener/GlossarySyncButtonProvider.php
+++ b/Classes/EventListener/GlossarySyncButtonProvider.php
@@ -15,6 +15,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
@@ -32,10 +33,10 @@ use WebVision\Deepltranslate\Glossary\Access\AllowedGlossarySyncAccess;
 #[Autoconfigure(public: true)]
 final class GlossarySyncButtonProvider
 {
-    private const ALLOWED_MODULES = [
-        'web_layout',
-        'web_list',
-    ];
+    public function __construct(
+        private Typo3Version $typo3Version,
+    ) {
+    }
 
     #[AsEventListener(identifier: 'glossary.syncbutton')]
     public function __invoke(ModifyButtonBarEvent $event): void
@@ -61,8 +62,8 @@ final class GlossarySyncButtonProvider
             || $normalizedParams === null
             || !empty($pageTSconfig['mod.']['SHARED.']['disableSysNoteButton'])
             || !$this->canCreateNewRecord($id)
-            || !in_array($module->getIdentifier(), self::ALLOWED_MODULES, true)
-            || ($module->getIdentifier() === 'web_list' && !$this->isCreationAllowed($pageTSconfig['mod.']['web_list.'] ?? []))
+            || !in_array($module->getIdentifier(), $this->getAllowedModules(), true)
+            || ($module->getIdentifier() === $this->getRecordsOrListModuleIdentifier() && !$this->isCreationAllowed($pageTSconfig['mod.']['web_list.'] ?? []))
             || !isset($page['module'])
             || $page['module'] !== 'glossary'
         ) {
@@ -154,5 +155,29 @@ final class GlossarySyncButtonProvider
             'uid' => $id,
             'returnUrl' => (string)$this->getRequest()->getAttribute('normalizedParams')?->getRequestUri(),
         ];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAllowedModules(): array
+    {
+        return [
+            $this->getPageLayoutModuleIdentifier(),
+            $this->getRecordsOrListModuleIdentifier(),
+        ];
+    }
+
+    private function getPageLayoutModuleIdentifier(): string
+    {
+        return 'web_layout';
+    }
+
+    private function getRecordsOrListModuleIdentifier(): string
+    {
+        return match($this->typo3Version->getMajorVersion()) {
+            13 => 'web_list',
+            default => 'records',
+        };
     }
 }

--- a/Classes/EventListener/GlossarySyncButtonProvider.php
+++ b/Classes/EventListener/GlossarySyncButtonProvider.php
@@ -35,6 +35,9 @@ final class GlossarySyncButtonProvider
 {
     public function __construct(
         private Typo3Version $typo3Version,
+        private LanguageServiceFactory $languageServiceFactory,
+        private IconFactory $iconFactory,
+        private UriBuilder $uriBuilder,
     ) {
     }
 
@@ -42,8 +45,7 @@ final class GlossarySyncButtonProvider
     public function __invoke(ModifyButtonBarEvent $event): void
     {
         $buttons = $event->getButtons();
-        $request = $this->getRequest();
-
+        $request = $this->getRequest($event);
         $requestParams = $request->getQueryParams();
 
         $id = (int)($requestParams['id'] ?? 0);
@@ -74,22 +76,20 @@ final class GlossarySyncButtonProvider
             return;
         }
 
-        $parameters = $this->buildParamsArrayForListView((int)$id);
-        $title = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+        $parameters = $this->buildParamsArrayForListView($request, (int)$id);
+        $title = $this->languageServiceFactory
             ->createFromUserPreferences($GLOBALS['BE_USER'] ?? null)
             ->sL('LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossary.sync.button.all');
         // Style button
-        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $button = $event->getButtonBar()->makeLinkButton();
-        $button->setIcon($iconFactory->getIcon(
+        $button->setIcon($this->iconFactory->getIcon(
             'apps-pagetree-folder-contains-glossary',
             IconSize::SMALL,
         ));
         $button->setTitle($title);
         $button->setShowLabelText(true);
 
-        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        $uri = $uriBuilder->buildUriFromRoute(
+        $uri = $this->uriBuilder->buildUriFromRoute(
             'glossaryupdate',
             $parameters
         );
@@ -101,8 +101,11 @@ final class GlossarySyncButtonProvider
         $event->setButtons($buttons);
     }
 
-    protected function getRequest(): ServerRequestInterface
+    protected function getRequest(ModifyButtonBarEvent $event): ServerRequestInterface
     {
+        if (method_exists($event, 'getRequest')) {
+            return $event->getRequest();
+        }
         return $GLOBALS['TYPO3_REQUEST'];
     }
 
@@ -149,11 +152,11 @@ final class GlossarySyncButtonProvider
     /**
      * @return array{uid: int, returnUrl: string|UriInterface}
      */
-    private function buildParamsArrayForListView(int $id): array
+    private function buildParamsArrayForListView(ServerRequestInterface $request, int $id): array
     {
         return [
             'uid' => $id,
-            'returnUrl' => (string)$this->getRequest()->getAttribute('normalizedParams')?->getRequestUri(),
+            'returnUrl' => (string)$request->getAttribute('normalizedParams')?->getRequestUri(),
         ];
     }
 


### PR DESCRIPTION
- **[TASK] DPL-158: Display `sync` button in `Records` module (v14)**
  TYPO3 v14 reworked the `List` module and also renamed the
  main module identifier for it and does not display the
  `Glossary Sync` button for the records module anymore.
  
  That boils down because the changed module identifier is
  checked against a hard-coded identifier list in PSR-14
  event listener `GlossarySyncButtonProvider`.
  
  This change migrates the event lister class constant for
  the allowed module identifiers to a private method along
  with two dedicated methods for module identifiers, one
  of them returning the module identifier based on the
  current TYPO3 version.
  
  `Glossary sync` button is now displayed for `Layout` and
  `Records` (former `List`) module again.
  

- **[TASK] DPL-158: Inject services using DI for `GlossarySyncButtonProvider`**
  This change streamlines the `GlossarySyncButtonProvider` to
  use constructor injection for used services and factories,
  and therefore following best-practice principles.
  