### PR TITLE
[TASK] DPL-158: Remove manual registration of custom `access` item

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,7 +15,4 @@ use WebVision\Deepltranslate\Glossary\Hooks\UpdatedGlossaryEntryTermHook;
     // hook registration
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
         = UpdatedGlossaryEntryTermHook::class;
-
-    $accessRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\WebVision\Deepltranslate\Core\Access\AccessRegistry::class);
-    $accessRegistry->addAccess((new \WebVision\Deepltranslate\Glossary\Access\AllowedGlossarySyncAccess()));
 })();


### PR DESCRIPTION
`EXT:deepltranslate_core` autoregisters access items now based on
the already mantandory `AccessItemInterface` making the manual
registration in `ext_localconf.php` obsolete. [1]

To avoid the connected `E_USER_DEPRECATED` error the manual
registration is now removed.

[1] https://github.com/web-vision/deepltranslate-core/pull/561
