### PR TITLE
[FEATURE] DeepL Glossary API v3

### DIFF
--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -34,8 +34,8 @@ jobs:
       - name: "Ensure UTF-8 files do not contain BOM"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkBom"
 
-#      - name: "Test .rst files for integrity"
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkRst"
+      - name: "Test .rst files for integrity"
+        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkRst"
 
       - name: "Find duplicate exception codes"
         run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"

--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -34,8 +34,8 @@ jobs:
       - name: "Ensure UTF-8 files do not contain BOM"
         run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkBom"
 
-#      - name: "Test .rst files for integrity"
-#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkRst"
+      - name: "Test .rst files for integrity"
+        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkRst"
 
       - name: "Find duplicate exception codes"
         run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkExceptionCodes"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -218,10 +218,10 @@ Options:
             - 16    maintained until 2028-11-09
 
     -t <13|14>
-        Only with -s composerInstall|composerInstallMin|composerInstallMax
+        Only with -s composerUpdate
         Specifies the TYPO3 CORE Version to be used
             - 13: (default) use TYPO3 v13
-            - 14: use TYPO3 v14 (~14.2.0@dev)
+            - 14: use TYPO3 v14 (~14.3.0@dev)
 
     -p <8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used

--- a/Build/Scripts/validateRstFiles.php
+++ b/Build/Scripts/validateRstFiles.php
@@ -148,19 +148,10 @@ class validateRstFiles
                 'title' => 'no title',
                 'message' => 'Each document must have a title with multiple === above and below',
             ],
-            [
-                'type' => 'titleinvalid',
-                'regex' => '#(\={2,}\n)(Deprecation|Feature|Breaking|Important)(\:\s+\#)([0-9]{4,8})(=?.*\n\={2,})#m',
-                'title' => 'invalid title format',
-                'message' => 'A changelog entry title must have the following format: '
-                    . '\'(Breaking|Feature|Deprecation|Important) #<issue nr>: <title>\'',
-            ],
-            [
-                'type' => 'titleformat',
-                'regex' => '#^See :issue:`[0-9]{4,6}`#m',
-                'title' => 'no reference',
-                'message' => 'insert \'See :issue:`<issuenumber>`\' after headline',
-            ],
+            // The TYPO3 core conventions of an issue number inside the headline and a
+            // `See :issue:` reference below it are intentionally not checked. This extension
+            // documents a change by its topic instead of by a Forge issue number, see the
+            // entries below `Documentation/Changelog`.
         ];
 
         foreach ($checkFor as $values) {

--- a/Classes/Client/GlossaryAPIV2Client.php
+++ b/Classes/Client/GlossaryAPIV2Client.php
@@ -15,6 +15,8 @@ use WebVision\Deepltranslate\Core\Client\DeepLClientFactoryInterface;
 
 /**
  * Client implementation for Glossary API v2, see {@see GlossaryAPIV2ClientInterface}.
+ *
+ * @deprecated since 6.1, will be removed in 7.0, use {@see GlossaryAPIV3Client}.
  * @internal No public API.
  */
 #[AsAlias(id: GlossaryAPIV2ClientInterface::class, public: true)]

--- a/Classes/Client/GlossaryAPIV2ClientInterface.php
+++ b/Classes/Client/GlossaryAPIV2ClientInterface.php
@@ -12,8 +12,8 @@ use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
 
 /**
  * Describes required implementation for Glossary API v2 compatible client implementations.
- * @depreacted in favour of upcoming GlossaryV3Interace and APIv3 handling.
- * @internal and not public API yet. Kept for refactoring towards APIv3.
+ * @deprecated since 6.1, will be removed in 7.0, use {@see GlossaryAPIV3ClientInterface}.
+ * @internal and not public API yet. Kept until the glossary API v2 is switched off.
  */
 interface GlossaryAPIV2ClientInterface extends DeepltranslateCoreClientInterface
 {

--- a/Classes/Client/GlossaryAPIV3Client.php
+++ b/Classes/Client/GlossaryAPIV3Client.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Client;
 
+use DeepL\DeepLException;
+use DeepL\GlossaryLanguagePair;
+use DeepL\MultilingualGlossaryDictionaryEntries;
+use DeepL\MultilingualGlossaryInfo;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use WebVision\Deepltranslate\Core\AbstractClient;
 use WebVision\Deepltranslate\Core\Client\DeepLClientFactoryInterface;
 
 /**
- * Client implementation for Glossary API v2, see {@see GlossaryAPIV2ClientInterface}.
+ * Client implementation for Glossary API v3, see {@see GlossaryAPIV3ClientInterface}.
  * @internal No public API.
  */
 #[AsAlias(id: GlossaryAPIV3ClientInterface::class, public: true)]
@@ -25,5 +29,113 @@ final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3C
         protected LoggerInterface $logger,
         protected DeepLClientFactoryInterface $clientFactory,
     ) {
+    }
+
+    /**
+     * @return GlossaryLanguagePair[]
+     */
+    public function getGlossaryLanguagePairs(): array
+    {
+        try {
+            return $this->client()->getGlossaryLanguages();
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return [];
+    }
+
+    public function getAllGlossaries(): array
+    {
+        try {
+            return $this->client()->listMultilingualGlossaries();
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return [];
+    }
+
+    public function getGlossary(string $glossaryId): MultilingualGlossaryInfo
+    {
+        try {
+            return $this->client()->getMultilingualGlossary($glossaryId);
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return new MultilingualGlossaryInfo(
+            '',
+            'Not defined',
+            new \DateTime(),
+            []
+        );
+    }
+
+    /**
+     * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     */
+    public function createGlossary(
+        string $glossaryName,
+        array $dictionaries,
+    ): MultilingualGlossaryInfo {
+        try {
+            return $this->client()->createMultilingualGlossary(
+                $glossaryName,
+                $dictionaries,
+            );
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return new MultilingualGlossaryInfo(
+            '',
+            'Not defined',
+            new \DateTime(),
+            []
+        );
+    }
+
+    public function updateGlossary(
+        string $glossaryId,
+        array $dictionaries,
+        ?string $name = null,
+    ): MultilingualGlossaryInfo {
+        try {
+            return $this->client()->updateMultilingualGlossary(
+                $glossaryId,
+                $name,
+                $dictionaries,
+            );
+        } catch (DeepLException $exception) {
+            $this->logger->error(sprintf(
+                '%s (%d)',
+                $exception->getMessage(),
+                $exception->getCode()
+            ));
+        }
+
+        return new MultilingualGlossaryInfo(
+            '',
+            'Not defined',
+            new \DateTime(),
+            []
+        );
     }
 }

--- a/Classes/Client/GlossaryAPIV3Client.php
+++ b/Classes/Client/GlossaryAPIV3Client.php
@@ -7,6 +7,7 @@ namespace WebVision\Deepltranslate\Glossary\Client;
 use DeepL\DeepLException;
 use DeepL\GlossaryLanguagePair;
 use DeepL\MultilingualGlossaryDictionaryEntries;
+use DeepL\MultilingualGlossaryDictionaryInfo;
 use DeepL\MultilingualGlossaryInfo;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
@@ -39,14 +40,8 @@ final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3C
         try {
             return $this->client()->getGlossaryLanguages();
         } catch (DeepLException $exception) {
-            $this->logger->error(sprintf(
-                '%s (%d)',
-                $exception->getMessage(),
-                $exception->getCode()
-            ));
+            $this->logAndRethrow($exception);
         }
-
-        return [];
     }
 
     public function getAllGlossaries(): array
@@ -54,14 +49,8 @@ final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3C
         try {
             return $this->client()->listMultilingualGlossaries();
         } catch (DeepLException $exception) {
-            $this->logger->error(sprintf(
-                '%s (%d)',
-                $exception->getMessage(),
-                $exception->getCode()
-            ));
+            $this->logAndRethrow($exception);
         }
-
-        return [];
     }
 
     public function getGlossary(string $glossaryId): MultilingualGlossaryInfo
@@ -69,19 +58,8 @@ final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3C
         try {
             return $this->client()->getMultilingualGlossary($glossaryId);
         } catch (DeepLException $exception) {
-            $this->logger->error(sprintf(
-                '%s (%d)',
-                $exception->getMessage(),
-                $exception->getCode()
-            ));
+            $this->logAndRethrow($exception);
         }
-
-        return new MultilingualGlossaryInfo(
-            '',
-            'Not defined',
-            new \DateTime(),
-            []
-        );
     }
 
     /**
@@ -97,21 +75,13 @@ final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3C
                 $dictionaries,
             );
         } catch (DeepLException $exception) {
-            $this->logger->error(sprintf(
-                '%s (%d)',
-                $exception->getMessage(),
-                $exception->getCode()
-            ));
+            $this->logAndRethrow($exception);
         }
-
-        return new MultilingualGlossaryInfo(
-            '',
-            'Not defined',
-            new \DateTime(),
-            []
-        );
     }
 
+    /**
+     * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     */
     public function updateGlossary(
         string $glossaryId,
         array $dictionaries,
@@ -124,18 +94,86 @@ final class GlossaryAPIV3Client extends AbstractClient implements GlossaryAPIV3C
                 $dictionaries,
             );
         } catch (DeepLException $exception) {
-            $this->logger->error(sprintf(
-                '%s (%d)',
-                $exception->getMessage(),
-                $exception->getCode()
-            ));
+            $this->logAndRethrow($exception);
         }
+    }
 
-        return new MultilingualGlossaryInfo(
-            '',
-            'Not defined',
-            new \DateTime(),
-            []
-        );
+    public function replaceDictionary(
+        string $glossaryId,
+        MultilingualGlossaryDictionaryEntries $dictionary,
+    ): MultilingualGlossaryDictionaryInfo {
+        try {
+            return $this->client()->replaceMultilingualGlossaryDictionary(
+                $glossaryId,
+                $dictionary,
+            );
+        } catch (DeepLException $exception) {
+            $this->logAndRethrow($exception);
+        }
+    }
+
+    public function deleteGlossary(string $glossaryId): void
+    {
+        try {
+            $this->client()->deleteMultilingualGlossary($glossaryId);
+        } catch (DeepLException $exception) {
+            $this->logAndRethrow($exception);
+        }
+    }
+
+    public function deleteDictionary(
+        string $glossaryId,
+        string $sourceLanguage,
+        string $targetLanguage,
+    ): void {
+        try {
+            $this->client()->deleteMultilingualGlossaryDictionary(
+                $glossaryId,
+                null,
+                $sourceLanguage,
+                $targetLanguage,
+            );
+        } catch (DeepLException $exception) {
+            $this->logAndRethrow($exception);
+        }
+    }
+
+    /**
+     * @return MultilingualGlossaryDictionaryEntries[]
+     */
+    public function getGlossaryEntries(
+        string $glossaryId,
+        string $sourceLanguage,
+        string $targetLanguage,
+    ): array {
+        try {
+            return $this->client()->getMultilingualGlossaryEntries(
+                $glossaryId,
+                $sourceLanguage,
+                $targetLanguage,
+            );
+        } catch (DeepLException $exception) {
+            $this->logAndRethrow($exception);
+        }
+    }
+
+    /**
+     * Logs the failed API call and rethrows the original exception.
+     *
+     * Returning a placeholder {@see MultilingualGlossaryInfo} instead would make a failed call
+     * indistinguishable from a successful one, so a caller would persist an empty glossary id
+     * together with a fresh synchronisation timestamp.
+     *
+     * @throws DeepLException
+     */
+    private function logAndRethrow(DeepLException $exception): never
+    {
+        $this->logger->error(sprintf(
+            '%s (%d)',
+            $exception->getMessage(),
+            $exception->getCode()
+        ));
+
+        throw $exception;
     }
 }

--- a/Classes/Client/GlossaryAPIV3ClientInterface.php
+++ b/Classes/Client/GlossaryAPIV3ClientInterface.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Client;
 
+use DeepL\GlossaryLanguagePair;
+use DeepL\MultilingualGlossaryDictionaryEntries;
+use DeepL\MultilingualGlossaryInfo;
 use WebVision\Deepltranslate\Core\ClientInterface as DeepltranslateCoreClientInterface;
+use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
 
 /**
  * Describes required implementation for Glossary API v3 compatible client implementations.
@@ -12,4 +16,42 @@ use WebVision\Deepltranslate\Core\ClientInterface as DeepltranslateCoreClientInt
  */
 interface GlossaryAPIV3ClientInterface extends DeepltranslateCoreClientInterface
 {
+    /**
+     * @return GlossaryLanguagePair[]
+     *
+     * @throws ApiKeyNotSetException
+     */
+    public function getGlossaryLanguagePairs(): array;
+
+    /**
+     * @return MultilingualGlossaryInfo[]
+     *
+     * @throws ApiKeyNotSetException
+     */
+    public function getAllGlossaries(): array;
+
+    /**
+     * @throws ApiKeyNotSetException
+     */
+    public function getGlossary(string $glossaryId): MultilingualGlossaryInfo;
+
+    /**
+     * @param string $glossaryName
+     * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     * @return MultilingualGlossaryInfo
+     */
+    public function createGlossary(
+        string $glossaryName,
+        array $dictionaries,
+    ): MultilingualGlossaryInfo;
+
+    /**
+     * @param non-empty-string $glossaryId
+     * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     */
+    public function updateGlossary(
+        string $glossaryId,
+        array $dictionaries,
+        ?string $name = null,
+    ): MultilingualGlossaryInfo;
 }

--- a/Classes/Client/GlossaryAPIV3ClientInterface.php
+++ b/Classes/Client/GlossaryAPIV3ClientInterface.php
@@ -4,14 +4,23 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Client;
 
+use DeepL\DeepLException;
 use DeepL\GlossaryLanguagePair;
+use DeepL\GlossaryNotFoundException;
 use DeepL\MultilingualGlossaryDictionaryEntries;
+use DeepL\MultilingualGlossaryDictionaryInfo;
 use DeepL\MultilingualGlossaryInfo;
 use WebVision\Deepltranslate\Core\ClientInterface as DeepltranslateCoreClientInterface;
 use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
 
 /**
  * Describes required implementation for Glossary API v3 compatible client implementations.
+ *
+ * Every method logs a failing API call and rethrows the original {@see DeepLException}. The
+ * concrete subclasses carry the information a caller needs to react, most notably
+ * {@see GlossaryNotFoundException} for a glossary removed on the DeepL side, so they must not
+ * be wrapped into an extension specific exception.
+ *
  * @internal and not public API yet. Methods will be added in minor versions implementing this API version.
  */
 interface GlossaryAPIV3ClientInterface extends DeepltranslateCoreClientInterface
@@ -20,6 +29,10 @@ interface GlossaryAPIV3ClientInterface extends DeepltranslateCoreClientInterface
      * @return GlossaryLanguagePair[]
      *
      * @throws ApiKeyNotSetException
+     * @throws DeepLException
+     * @todo Switch to `GET /v3/languages?resource=glossary` once the DeepL mock server implements
+     *       it and `deeplcom/deepl-php` exposes `getLanguagesForResource()` through the core client
+     *       interface. The v2 endpoint is deprecated by DeepL and does not report newer languages.
      */
     public function getGlossaryLanguagePairs(): array;
 
@@ -27,18 +40,23 @@ interface GlossaryAPIV3ClientInterface extends DeepltranslateCoreClientInterface
      * @return MultilingualGlossaryInfo[]
      *
      * @throws ApiKeyNotSetException
+     * @throws DeepLException
      */
     public function getAllGlossaries(): array;
 
     /**
      * @throws ApiKeyNotSetException
+     * @throws GlossaryNotFoundException
+     * @throws DeepLException
      */
     public function getGlossary(string $glossaryId): MultilingualGlossaryInfo;
 
     /**
      * @param string $glossaryName
      * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
-     * @return MultilingualGlossaryInfo
+     *
+     * @throws ApiKeyNotSetException
+     * @throws DeepLException
      */
     public function createGlossary(
         string $glossaryName,
@@ -46,12 +64,66 @@ interface GlossaryAPIV3ClientInterface extends DeepltranslateCoreClientInterface
     ): MultilingualGlossaryInfo;
 
     /**
-     * @param non-empty-string $glossaryId
+     * Merges the given dictionaries into the glossary and optionally renames it.
+     *
+     * Entries of an already existing language pair are merged, not replaced. Use
+     * {@see self::replaceDictionary()} to mirror a TYPO3 glossary folder, otherwise terms
+     * removed in TYPO3 remain in the DeepL dictionary.
+     *
      * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     *
+     * @throws ApiKeyNotSetException
+     * @throws GlossaryNotFoundException
+     * @throws DeepLException
      */
     public function updateGlossary(
         string $glossaryId,
         array $dictionaries,
         ?string $name = null,
     ): MultilingualGlossaryInfo;
+
+    /**
+     * Replaces the dictionary of the given language pair completely, or creates it when the
+     * glossary does not contain that language pair yet.
+     *
+     *
+     * @throws ApiKeyNotSetException
+     * @throws GlossaryNotFoundException
+     * @throws DeepLException
+     */
+    public function replaceDictionary(
+        string $glossaryId,
+        MultilingualGlossaryDictionaryEntries $dictionary,
+    ): MultilingualGlossaryDictionaryInfo;
+
+    /**
+     * @throws ApiKeyNotSetException
+     * @throws GlossaryNotFoundException
+     * @throws DeepLException
+     */
+    public function deleteGlossary(string $glossaryId): void;
+
+    /**
+     * @throws ApiKeyNotSetException
+     * @throws GlossaryNotFoundException
+     * @throws DeepLException
+     */
+    public function deleteDictionary(
+        string $glossaryId,
+        string $sourceLanguage,
+        string $targetLanguage,
+    ): void;
+
+    /**
+     * @return MultilingualGlossaryDictionaryEntries[]
+     *
+     * @throws ApiKeyNotSetException
+     * @throws GlossaryNotFoundException
+     * @throws DeepLException
+     */
+    public function getGlossaryEntries(
+        string $glossaryId,
+        string $sourceLanguage,
+        string $targetLanguage,
+    ): array;
 }

--- a/Classes/Command/GlossaryCleanupCommand.php
+++ b/Classes/Command/GlossaryCleanupCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Command;
 
-use DeepL\GlossaryInfo;
+use DeepL\GlossaryNotFoundException;
+use DeepL\MultilingualGlossaryInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,8 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\Service\Attribute\Required;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
 use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
-use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
 
 /**
  * @todo: Rename Command
@@ -26,13 +27,13 @@ use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
 )]
 final class GlossaryCleanupCommand extends Command
 {
-    private DeeplGlossaryService $deeplGlossaryService;
+    private GlossaryAPIV3ClientInterface $client;
     private GlossaryRepository $glossaryRepository;
 
     #[Required]
-    public function injectDeeplGlossaryService(DeeplGlossaryService $deeplGlossaryService): void
+    public function injectGlossaryClient(GlossaryAPIV3ClientInterface $client): void
     {
-        $this->deeplGlossaryService = $deeplGlossaryService;
+        $this->client = $client;
     }
 
     #[Required]
@@ -87,7 +88,7 @@ final class GlossaryCleanupCommand extends Command
         }
         // Remove all glossaries
         if (!empty($input->getOption('all'))) {
-            $glossaries = $this->deeplGlossaryService->listGlossaries();
+            $glossaries = $this->client->getAllGlossaries();
             if (empty($glossaries)) {
                 $io->info('No glossaries found with sync to API');
                 return Command::FAILURE;
@@ -119,12 +120,17 @@ final class GlossaryCleanupCommand extends Command
 
     private function removeGlossary(string $id): bool
     {
-        $this->deeplGlossaryService->deleteGlossary($id);
+        try {
+            $this->client->deleteGlossary($id);
+        } catch (GlossaryNotFoundException) {
+            // Already gone at DeepL, the local synchronisation state still has to be cleared.
+        }
+
         return $this->glossaryRepository->removeGlossarySync($id);
     }
 
     /**
-     * @param GlossaryInfo[] $glossaries
+     * @param MultilingualGlossaryInfo[] $glossaries
      */
     private function removeGlossaries(SymfonyStyle $io, array $glossaries): void
     {

--- a/Classes/Command/GlossaryListCommand.php
+++ b/Classes/Command/GlossaryListCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Glossary\Command;
 
 use DateTime;
-use DeepL\GlossaryInfo;
+use DeepL\MultilingualGlossaryInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\Service\Attribute\Required;
-use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
 
 #[AsCommand(
     name: 'deepl:glossary:list',
@@ -21,12 +21,12 @@ use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
 )]
 final class GlossaryListCommand extends Command
 {
-    private DeeplGlossaryService $deeplGlossaryService;
+    private GlossaryAPIV3ClientInterface $client;
 
     #[Required]
-    public function injectDeeplGlossaryService(DeeplGlossaryService $deeplGlossaryService): void
+    public function injectGlossaryClient(GlossaryAPIV3ClientInterface $client): void
     {
-        $this->deeplGlossaryService = $deeplGlossaryService;
+        $this->client = $client;
     }
 
     protected function configure(): void
@@ -44,84 +44,100 @@ final class GlossaryListCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Glossary List');
 
-        $glossary_id = $input->getArgument('glossary_id');
+        $glossaryId = $input->getArgument('glossary_id');
+        if ($glossaryId !== null) {
+            $this->listSingleGlossary($io, (string)$glossaryId);
 
-        if ($glossary_id !== null) {
-            $this->listAllGlossaryEntriesById($io, $glossary_id);
-        } else {
-            $this->listAllGlossaryEntries($io);
+            return Command::SUCCESS;
         }
+
+        $this->listAllGlossaries($io);
 
         return Command::SUCCESS;
     }
 
-    private function listAllGlossaryEntries(SymfonyStyle $io): void
+    private function listAllGlossaries(SymfonyStyle $io): void
     {
-        $glossaries = $this->deeplGlossaryService->listGlossaries();
+        $glossaries = $this->client->getAllGlossaries();
 
-        $io->info('Read more here: https://www.deepl.com/docs-api/managing-glossaries/listing-glossaries/');
+        $io->info('Read more here: https://developers.deepl.com/docs/customize/managing-glossaries');
         if ($glossaries === []) {
             $io->info('No Glossaries found.');
             return;
         }
 
-        $headers = [
-            'Glossary ID',
-            'Name',
-            'Ready',
-            'Source Language',
-            'Target Language',
-            'Creation Time',
-            'Entry count',
-        ];
-
-        $rows = array_map(function (GlossaryInfo $glossary) {
-            return [
-                'glossaryId' => $glossary->glossaryId,
-                'name' => $glossary->name,
-                'ready' => $glossary->ready,
-                'sourceLang' => $glossary->sourceLang,
-                'targetLang' => $glossary->targetLang,
-                'creationTime' => $glossary->creationTime->format(DateTime::ATOM),
-                'entryCount' => $glossary->entryCount,
+        $rows = [];
+        foreach ($glossaries as $glossary) {
+            $rows[] = [
+                $glossary->glossaryId,
+                $glossary->name,
+                $this->describeDictionaries($glossary),
+                $glossary->creationTime->format(DateTime::ATOM),
             ];
-        }, $glossaries);
+        }
 
-        $io->table($headers, $rows);
+        $io->table(
+            [
+                'Glossary ID',
+                'Name',
+                'Dictionaries',
+                'Creation Time',
+            ],
+            $rows
+        );
     }
 
-    private function listAllGlossaryEntriesById(SymfonyStyle $io, string $id): void
+    private function listSingleGlossary(SymfonyStyle $io, string $glossaryId): void
     {
-        $glossaryInformation = $this->deeplGlossaryService->glossaryInformation($id);
-        if ($glossaryInformation === null) {
-            $io->warning(sprintf('Glossary "%s" not found.', $id));
-            return;
-        }
-        if ($glossaryInformation->entryCount === 0) {
-            $io->warning(sprintf('Glossary "%s" has no entries.', $id));
-            return;
-        }
-        $entries = $this->deeplGlossaryService->glossaryEntries($id);
-        if ($entries === null) {
-            $io->error(sprintf('No entries found in glossary with ID "%s", but count has "%d" entries.', $id, $glossaryInformation->entryCount));
+        $glossary = $this->client->getGlossary($glossaryId);
+        if ($glossary->dictionaries === []) {
+            $io->warning(sprintf('Glossary "%s" has no dictionaries.', $glossaryId));
             return;
         }
 
         $io->writeln([
-            sprintf('Glossary entries from: %s', $glossaryInformation->glossaryId),
-            sprintf('Entries count: %s', $glossaryInformation->entryCount),
-            sprintf('Is ready: %s', $glossaryInformation->ready ? 'yes' : 'no'),
-            sprintf('Creation Time: %s', $glossaryInformation->creationTime->format(DateTime::ATOM)),
+            sprintf('Glossary: %s', $glossary->glossaryId),
+            sprintf('Name: %s', $glossary->name),
+            sprintf('Creation Time: %s', $glossary->creationTime->format(DateTime::ATOM)),
         ]);
-        $io->newLine();
 
-        $rows = array_map(null, array_keys($entries->getEntries()), $entries->getEntries());
+        foreach ($glossary->dictionaries as $dictionary) {
+            $io->newLine();
+            $io->section(sprintf('%s => %s', $dictionary->sourceLang, $dictionary->targetLang));
+            $this->renderEntries($io, $glossaryId, $dictionary->sourceLang, $dictionary->targetLang);
+        }
+    }
+
+    private function renderEntries(SymfonyStyle $io, string $glossaryId, string $sourceLang, string $targetLang): void
+    {
+        $rows = [];
+        foreach ($this->client->getGlossaryEntries($glossaryId, $sourceLang, $targetLang) as $dictionary) {
+            foreach ($dictionary->entries as $source => $target) {
+                $rows[] = [$source, $target];
+            }
+        }
+
         $io->table(
             [
-                'source_lang: ' . $glossaryInformation->sourceLang,
-                'target_lang:' . $glossaryInformation->targetLang,
+                'source_lang: ' . $sourceLang,
+                'target_lang: ' . $targetLang,
             ],
             $rows
         );
+    }
+
+    private function describeDictionaries(MultilingualGlossaryInfo $glossary): string
+    {
+        $pairs = [];
+        foreach ($glossary->dictionaries as $dictionary) {
+            $pairs[] = sprintf(
+                '%s => %s (%d)',
+                $dictionary->sourceLang,
+                $dictionary->targetLang,
+                $dictionary->entryCount
+            );
+        }
+
+        return implode(', ', $pairs);
     }
 }

--- a/Classes/Command/GlossarySyncCommand.php
+++ b/Classes/Command/GlossarySyncCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\Service\Attribute\Required;
 use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
-use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
 
 #[AsCommand(
     name: 'deepl:glossary:sync',
@@ -21,13 +21,13 @@ use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
 )]
 final class GlossarySyncCommand extends Command
 {
-    private DeeplGlossaryService $deeplGlossaryService;
+    private MultilingualGlossaryService $multilingualGlossaryService;
     private GlossaryRepository $glossaryRepository;
 
     #[Required]
-    public function injectDeeplGlossaryService(DeeplGlossaryService $deeplGlossaryService): void
+    public function injectMultilingualGlossaryService(MultilingualGlossaryService $multilingualGlossaryService): void
     {
-        $this->deeplGlossaryService = $deeplGlossaryService;
+        $this->multilingualGlossaryService = $multilingualGlossaryService;
     }
 
     #[Required]
@@ -63,7 +63,7 @@ final class GlossarySyncCommand extends Command
 
             $io->progressStart(count($glossaries));
             foreach ($glossaries as $glossary) {
-                $this->deeplGlossaryService->syncGlossaries($glossary['uid']);
+                $this->multilingualGlossaryService->syncGlossary((int)$glossary['uid']);
                 $io->progressAdvance();
             }
             $io->progressFinish();

--- a/Classes/Controller/GlossarySyncController.php
+++ b/Classes/Controller/GlossarySyncController.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException;
 use WebVision\Deepltranslate\Glossary\Exception\FailedToCreateGlossaryException;
-use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
 
 /**
  * Synchronization Controller for local deepltranslate glossary
@@ -32,7 +32,7 @@ final class GlossarySyncController
     private LanguageService $languageService;
 
     public function __construct(
-        private readonly DeeplGlossaryService $deeplGlossaryService,
+        private readonly MultilingualGlossaryService $multilingualGlossaryService,
         private readonly FlashMessageService $flashMessageService,
         LanguageServiceFactory $languageServiceFactory
     ) {
@@ -74,7 +74,7 @@ final class GlossarySyncController
         }
 
         try {
-            $this->deeplGlossaryService->syncGlossaries((int)$processingParameters['uid']);
+            $this->multilingualGlossaryService->syncGlossary((int)$processingParameters['uid']);
             $this->flashMessageService->getMessageQueueByIdentifier()->enqueue(new FlashMessage(
                 $this->languageService->sL('LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossary.sync.message'),
                 $this->languageService->sL('LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossary.sync.title'),

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Glossary\Domain\Repository;
 
 use DeepL\GlossaryInfo;
+use DeepL\MultilingualGlossaryInfo;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Configuration\TranslationConfigurationProvider;
@@ -124,6 +125,251 @@ final class GlossaryRepository
         }
 
         return $glossaries;
+    }
+
+    /**
+     * Collects the term pairs of a glossary folder grouped by language pair, without touching
+     * any record. Used by the glossary API v3 synchronisation, which needs the dictionaries of
+     * a folder before it knows whether a glossary has to be created at all.
+     *
+     * @return array<int, array{sourceLanguage: string, targetLanguage: string, entries: array<string, string>}>
+     *
+     * @throws DBALException
+     * @throws Exception
+     * @throws SiteNotFoundException
+     */
+    public function getDictionaryDataForSync(int $pageId): array
+    {
+        $localizationArray = $this->collectTermsByLanguage($pageId);
+        if ($localizationArray === []) {
+            return [];
+        }
+        $sourceLangIsoCode = GeneralUtility::makeInstance(SiteFinder::class)
+            ->getSiteByPageId($pageId)
+            ->getDefaultLanguage()
+            ->getLocale()
+            ->getLanguageCode();
+
+        $dictionaries = [];
+        foreach ($this->getPossibleLanguagePairs() as $sourceLang => $availableTargets) {
+            foreach ($availableTargets as $targetLang) {
+                if ($targetLang === $sourceLangIsoCode) {
+                    continue;
+                }
+                $entries = $this->buildEntriesForPair($localizationArray, $sourceLang, $targetLang);
+                if ($entries === []) {
+                    continue;
+                }
+                $dictionaries[] = [
+                    'sourceLanguage' => $sourceLang,
+                    'targetLanguage' => $targetLang,
+                    'entries' => $entries,
+                ];
+            }
+        }
+
+        return $dictionaries;
+    }
+
+    /**
+     * Returns the single glossary record of a folder, creating it when the folder has none yet.
+     *
+     * @return array{uid: int, glossary_id: string, glossary_name: string}
+     *
+     * @throws Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function findOrCreateGlossaryRecord(int $pageId): array
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossary');
+        $record = $connection
+            ->select(['uid', 'glossary_id', 'glossary_name'], 'tx_deepltranslate_glossary', ['pid' => $pageId], [], ['uid' => 'ASC'], 1)
+            ->fetchAssociative();
+        if ($record !== false) {
+            /** @var array{uid: int, glossary_id: string, glossary_name: string} $record */
+            return $record;
+        }
+
+        $page = BackendUtility::getRecord('pages', $pageId, 'uid,title');
+        $glossaryName = sprintf('%s [%d]', $page['title'] ?? 'Glossary', $pageId);
+        $connection->insert(
+            'tx_deepltranslate_glossary',
+            [
+                'pid' => $pageId,
+                'glossary_id' => '',
+                'glossary_name' => $glossaryName,
+                'glossary_lastsync' => 0,
+                'glossary_ready' => 0,
+            ]
+        );
+
+        return [
+            'uid' => (int)$connection->lastInsertId(),
+            'glossary_id' => '',
+            'glossary_name' => $glossaryName,
+        ];
+    }
+
+    /**
+     * Mirrors the state DeepL reported back onto the glossary record and its dictionaries.
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function updateGlossaryRecord(MultilingualGlossaryInfo $information, int $uid, int $pageId): void
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossary')
+            ->update(
+                'tx_deepltranslate_glossary',
+                [
+                    'glossary_id' => $information->glossaryId,
+                    'glossary_name' => $information->name,
+                    'glossary_lastsync' => $information->creationTime->getTimestamp(),
+                    'glossary_ready' => 1,
+                ],
+                ['uid' => $uid]
+            );
+
+        $this->replaceDictionaryRecords($information, $uid, $pageId);
+    }
+
+    /**
+     * Detaches the folder from its remote glossary, used when nothing is left to synchronise.
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function resetGlossaryRecord(int $uid): void
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossary')
+            ->update(
+                'tx_deepltranslate_glossary',
+                [
+                    'glossary_id' => '',
+                    'glossary_lastsync' => 0,
+                    'glossary_ready' => 0,
+                ],
+                ['uid' => $uid]
+            );
+
+        $this->deleteDictionaryRecords($uid);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function replaceDictionaryRecords(MultilingualGlossaryInfo $information, int $uid, int $pageId): void
+    {
+        $this->deleteDictionaryRecords($uid);
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossarydictionary');
+        foreach ($information->dictionaries as $dictionary) {
+            $connection->insert(
+                'tx_deepltranslate_glossarydictionary',
+                [
+                    'pid' => $pageId,
+                    'glossary' => $uid,
+                    'source_lang' => $dictionary->sourceLang,
+                    'target_lang' => $dictionary->targetLang,
+                    'entry_count' => $dictionary->entryCount,
+                    'in_sync' => 1,
+                ]
+            );
+        }
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function deleteDictionaryRecords(int $uid): void
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossarydictionary')
+            ->delete('tx_deepltranslate_glossarydictionary', ['glossary' => $uid]);
+    }
+
+    /**
+     * @return array<string, array<int, array{uid: int, term: string}>>
+     *
+     * @throws DBALException
+     * @throws Exception
+     * @throws SiteNotFoundException
+     */
+    private function collectTermsByLanguage(int $pageId): array
+    {
+        $entries = $this->getOriginalEntries($pageId);
+        if ($entries === []) {
+            return [];
+        }
+        $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId);
+        $localizationArray = [
+            $site->getDefaultLanguage()->getLocale()->getLanguageCode() => $this->normalizeTerms($entries),
+        ];
+        foreach ($this->getAvailableLocalizations($pageId) as $localizationLanguageId) {
+            $localizationArray[$this->getTargetLanguageIsoCode($site, $localizationLanguageId)]
+                = $this->normalizeTerms($this->getLocalizedEntries($pageId, $localizationLanguageId));
+        }
+
+        return $localizationArray;
+    }
+
+    /**
+     * @param array<string, array<int, array{uid: int, term: string}>> $localizationArray
+     * @return array<string, string>
+     */
+    private function buildEntriesForPair(array $localizationArray, string $sourceLang, string $targetLang): array
+    {
+        if (!isset($localizationArray[$sourceLang], $localizationArray[$targetLang])) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($localizationArray[$sourceLang] as $entryId => $sourceEntry) {
+            if (!isset($localizationArray[$targetLang][$entryId])) {
+                continue;
+            }
+            // A source term occurring twice would be sent to DeepL twice, the first pair wins.
+            if (isset($entries[$sourceEntry['term']])) {
+                continue;
+            }
+            $entries[$sourceEntry['term']] = $localizationArray[$targetLang][$entryId]['term'];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * The rows come straight from the database, so both key and value types are widened. The
+     * dictionary building relies on the term of a translation being addressable by the uid of
+     * its default language record.
+     *
+     * @param array<int|string, mixed> $rows
+     * @return array<int, array{uid: int, term: string}>
+     */
+    private function normalizeTerms(array $rows): array
+    {
+        $terms = [];
+        foreach ($rows as $key => $row) {
+            if (!is_array($row) || !isset($row['term'])) {
+                continue;
+            }
+            $terms[(int)$key] = [
+                'uid' => (int)($row['uid'] ?? 0),
+                'term' => (string)$row['term'],
+            ];
+        }
+
+        return $terms;
+    }
+
+    /**
+     * @return array<string, array<array-key, string>>
+     */
+    private function getPossibleLanguagePairs(): array
+    {
+        return GeneralUtility::makeInstance(DeeplGlossaryService::class)
+            ->getPossibleGlossaryLanguageConfig();
     }
 
     /**

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -459,12 +459,57 @@ final class GlossaryRepository
         if (strlen($lowerTargetLang) > 2) {
             $lowerTargetLang = substr($lowerTargetLang, 0, 2);
         }
-        return $this->getGlossary(
+        return $this->getGlossaryByDictionary(
             $lowerSourceLang,
             $lowerTargetLang,
-            $page->uid,
-            true
+            $page->uid
         ) ?? $defaultGlossary;
+    }
+
+    /**
+     * Resolves the glossary of a folder covering the wanted language pair.
+     *
+     * A glossary of the API v3 is valid for every language pair one of its dictionaries covers,
+     * so the pair is matched on the dictionaries and not on the glossary record.
+     *
+     * @throws Exception
+     * @throws SiteNotFoundException
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function getGlossaryByDictionary(
+        string $sourceLanguage,
+        string $targetLanguage,
+        int $pageUid
+    ): ?Glossary {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossary');
+        $constraints = [
+            $queryBuilder->expr()->eq('d.source_lang', $queryBuilder->createNamedParameter($sourceLanguage)),
+            $queryBuilder->expr()->eq('d.target_lang', $queryBuilder->createNamedParameter($targetLanguage)),
+        ];
+        // Folders of the current site take precedence. A folder not marked as glossary module
+        // is still honoured, otherwise instances synchronising through the command line only
+        // would silently lose their glossary.
+        $glossaryPages = $this->getGlossariesInRootByCurrentPage($pageUid);
+        if ($glossaryPages !== []) {
+            $constraints[] = $queryBuilder->expr()->in('g.pid', $glossaryPages);
+        }
+
+        $result = $queryBuilder
+            ->select('g.uid', 'g.glossary_id', 'g.glossary_name', 'g.glossary_lastsync', 'g.glossary_ready')
+            ->from('tx_deepltranslate_glossary', 'g')
+            ->innerJoin(
+                'g',
+                'tx_deepltranslate_glossarydictionary',
+                'd',
+                $queryBuilder->expr()->eq('d.glossary', $queryBuilder->quoteIdentifier('g.uid'))
+            )
+            ->where(...$constraints)
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return $result ? Glossary::fromDatabase($result) : null;
     }
 
     /**
@@ -517,6 +562,14 @@ final class GlossaryRepository
     {
         $db = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_deepltranslate_glossary');
+
+        // The dictionaries describe the state of a glossary which is about to be dropped, so
+        // they would otherwise survive as records of a glossary that no longer exists.
+        $affected = $db->select(['uid'], 'tx_deepltranslate_glossary', ['glossary_id' => $glossaryId])
+            ->fetchAllAssociative();
+        foreach ($affected as $glossary) {
+            $this->deleteDictionaryRecords((int)$glossary['uid']);
+        }
 
         $count = $db->update(
             'tx_deepltranslate_glossary',

--- a/Classes/Service/DeeplGlossaryService.php
+++ b/Classes/Service/DeeplGlossaryService.php
@@ -18,6 +18,13 @@ use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
 use WebVision\Deepltranslate\Glossary\Exception\FailedToCreateGlossaryException;
 use WebVision\Deepltranslate\Glossary\Exception\GlossaryEntriesNotExistException;
 
+/**
+ * Glossary handling based on the DeepL glossary API v2.
+ *
+ * @deprecated since 6.1, will be removed in 7.0. The extension synchronises through
+ *             {@see MultilingualGlossaryService} and the glossary API v3. This class is kept
+ *             for consumers still relying on it and is no longer used internally.
+ */
 #[Autoconfigure(public: true)]
 final readonly class DeeplGlossaryService
 {

--- a/Classes/Service/MultilingualGlossaryService.php
+++ b/Classes/Service/MultilingualGlossaryService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Service;
+
+use DeepL\DeepLException;
+use DeepL\MultilingualGlossaryDictionaryEntries;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+/**
+ * This service defines helper methods for handling with multilingual Glossaries
+ */
+#[Autoconfigure(public: true)]
+final class MultilingualGlossaryService
+{
+    /**
+     * $entries is an associative array where key is the source language and value is the target language
+     * For example (The source language is English, target language is German):
+     * [
+     *     'hello' => 'Guten Tag',
+     *     'University of Applied Sciences' => 'Fachhochschule',
+     * ]
+     *
+     * @param non-empty-string $sourceLanguage
+     * @param non-empty-string $targetLanguage
+     * @param array<string, string> $entries
+     * @throws DeepLException
+     */
+    public function createDictionary(
+        string $sourceLanguage,
+        string $targetLanguage,
+        array $entries,
+    ): MultilingualGlossaryDictionaryEntries {
+        return new MultilingualGlossaryDictionaryEntries(
+            $sourceLanguage,
+            $targetLanguage,
+            $entries
+        );
+    }
+}

--- a/Classes/Service/MultilingualGlossaryService.php
+++ b/Classes/Service/MultilingualGlossaryService.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Glossary\Service;
 
 use DeepL\DeepLException;
+use DeepL\GlossaryNotFoundException;
 use DeepL\MultilingualGlossaryDictionaryEntries;
+use DeepL\MultilingualGlossaryInfo;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
+use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
 
 /**
  * This service defines helper methods for handling with multilingual Glossaries
@@ -14,6 +18,107 @@ use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 #[Autoconfigure(public: true)]
 final class MultilingualGlossaryService
 {
+    public function __construct(
+        private readonly GlossaryAPIV3ClientInterface $client,
+        private readonly GlossaryRepository $glossaryRepository,
+    ) {
+    }
+
+    /**
+     * Mirrors a glossary folder onto its persistent DeepL glossary.
+     *
+     * The glossary of a folder is created once and edited afterwards, so the glossary id stays
+     * stable and pages referencing it keep working across synchronisations.
+     *
+     * @throws DeepLException
+     */
+    public function syncGlossary(int $pageId): void
+    {
+        $dictionaryData = $this->glossaryRepository->getDictionaryDataForSync($pageId);
+        $record = $this->glossaryRepository->findOrCreateGlossaryRecord($pageId);
+
+        if ($dictionaryData === []) {
+            $this->dropGlossary($record);
+            return;
+        }
+
+        $dictionaries = [];
+        foreach ($dictionaryData as $dictionary) {
+            $dictionaries[] = $this->createDictionary(
+                $dictionary['sourceLanguage'],
+                $dictionary['targetLanguage'],
+                $dictionary['entries']
+            );
+        }
+
+        $information = $this->pushDictionaries($record, $dictionaries);
+        $this->glossaryRepository->updateGlossaryRecord($information, (int)$record['uid'], $pageId);
+    }
+
+    /**
+     * @param array{uid: int, glossary_id: string, glossary_name: string} $record
+     * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     *
+     * @throws DeepLException
+     */
+    private function pushDictionaries(array $record, array $dictionaries): MultilingualGlossaryInfo
+    {
+        if ($record['glossary_id'] === '') {
+            return $this->client->createGlossary($record['glossary_name'], $dictionaries);
+        }
+
+        try {
+            return $this->updateExistingGlossary($record['glossary_id'], $dictionaries);
+        } catch (GlossaryNotFoundException) {
+            // The glossary was removed on the DeepL side, so the stored id is worthless and the
+            // folder is published again as a new glossary.
+            return $this->client->createGlossary($record['glossary_name'], $dictionaries);
+        }
+    }
+
+    /**
+     * @param MultilingualGlossaryDictionaryEntries[] $dictionaries
+     *
+     * @throws DeepLException
+     */
+    private function updateExistingGlossary(string $glossaryId, array $dictionaries): MultilingualGlossaryInfo
+    {
+        $configuredPairs = [];
+        foreach ($dictionaries as $dictionary) {
+            // Replacing instead of merging, so a term removed in TYPO3 disappears at DeepL too.
+            $this->client->replaceDictionary($glossaryId, $dictionary);
+            $configuredPairs[] = $dictionary->sourceLang . '-' . $dictionary->targetLang;
+        }
+
+        foreach ($this->client->getGlossary($glossaryId)->dictionaries as $remoteDictionary) {
+            $pair = $remoteDictionary->sourceLang . '-' . $remoteDictionary->targetLang;
+            if (in_array($pair, $configuredPairs, true)) {
+                continue;
+            }
+            $this->client->deleteDictionary($glossaryId, $remoteDictionary->sourceLang, $remoteDictionary->targetLang);
+        }
+
+        return $this->client->getGlossary($glossaryId);
+    }
+
+    /**
+     * @param array{uid: int, glossary_id: string, glossary_name: string} $record
+     *
+     * @throws DeepLException
+     */
+    private function dropGlossary(array $record): void
+    {
+        if ($record['glossary_id'] !== '') {
+            try {
+                $this->client->deleteGlossary($record['glossary_id']);
+            } catch (GlossaryNotFoundException) {
+                // Already gone on the DeepL side, only the local state needs cleaning up.
+            }
+        }
+
+        $this->glossaryRepository->resetGlossaryRecord((int)$record['uid']);
+    }
+
     /**
      * $entries is an associative array where key is the source language and value is the target language
      * For example (The source language is English, target language is German):
@@ -24,8 +129,6 @@ final class MultilingualGlossaryService
      *
      * Terms are trimmed and unusable pairs are dropped, see {@see self::sanitizeEntries()}.
      *
-     * @param non-empty-string $sourceLanguage
-     * @param non-empty-string $targetLanguage
      * @param array<string, string> $entries
      * @throws DeepLException
      */

--- a/Classes/Service/MultilingualGlossaryService.php
+++ b/Classes/Service/MultilingualGlossaryService.php
@@ -22,6 +22,8 @@ final class MultilingualGlossaryService
      *     'University of Applied Sciences' => 'Fachhochschule',
      * ]
      *
+     * Terms are trimmed and unusable pairs are dropped, see {@see self::sanitizeEntries()}.
+     *
      * @param non-empty-string $sourceLanguage
      * @param non-empty-string $targetLanguage
      * @param array<string, string> $entries
@@ -35,7 +37,35 @@ final class MultilingualGlossaryService
         return new MultilingualGlossaryDictionaryEntries(
             $sourceLanguage,
             $targetLanguage,
-            $entries
+            $this->sanitizeEntries($entries)
         );
+    }
+
+    /**
+     * Trims both sides of a term pair and drops pairs which are unusable afterwards.
+     *
+     * DeepL rejects a term without non-whitespace characters and answers the whole request with
+     * an error. A single term an editor left unfilled would therefore abort the synchronisation
+     * of an entire glossary folder, so such pairs are skipped instead.
+     *
+     * Trimming can let two source terms collapse into the same key, in which case the last pair
+     * wins. Reducing the terms to what DeepL accepts is the wanted behaviour here.
+     *
+     * @param array<string, string> $entries
+     * @return array<string, string>
+     */
+    private function sanitizeEntries(array $entries): array
+    {
+        $sanitizedEntries = [];
+        foreach ($entries as $source => $target) {
+            $trimmedSource = trim((string)$source);
+            $trimmedTarget = trim($target);
+            if ($trimmedSource === '' || $trimmedTarget === '') {
+                continue;
+            }
+            $sanitizedEntries[$trimmedSource] = $trimmedTarget;
+        }
+
+        return $sanitizedEntries;
     }
 }

--- a/Classes/Upgrade/MigrateToMultilingualGlossaryWizard.php
+++ b/Classes/Upgrade/MigrateToMultilingualGlossaryWizard.php
@@ -20,8 +20,6 @@ use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
 #[UpgradeWizard(identifier: 'deepltranslateGlossary_migrateToMultilingualGlossary')]
 final readonly class MigrateToMultilingualGlossaryWizard implements UpgradeWizardInterface
 {
-    private const TABLE = 'tx_deepltranslate_glossary';
-
     public function __construct(
         private ConnectionPool $connectionPool,
         private GlossaryAPIV3ClientInterface $client,
@@ -43,11 +41,11 @@ final readonly class MigrateToMultilingualGlossaryWizard implements UpgradeWizar
 
     public function updateNecessary(): bool
     {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_deepltranslate_glossary');
 
         return (int)$queryBuilder
             ->count('uid')
-            ->from(self::TABLE)
+            ->from('tx_deepltranslate_glossary')
             ->where(
                 $queryBuilder->expr()->neq(
                     'source_lang',
@@ -87,11 +85,11 @@ final readonly class MigrateToMultilingualGlossaryWizard implements UpgradeWizar
      */
     private function getFolderIdsToMigrate(): array
     {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_deepltranslate_glossary');
         $rows = $queryBuilder
             ->select('pid')
             ->distinct()
-            ->from(self::TABLE)
+            ->from('tx_deepltranslate_glossary')
             ->where(
                 $queryBuilder->expr()->neq(
                     'source_lang',
@@ -109,11 +107,11 @@ final readonly class MigrateToMultilingualGlossaryWizard implements UpgradeWizar
      */
     private function getGlossaryRecordsOfFolder(int $pageId): array
     {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_deepltranslate_glossary');
 
         return $queryBuilder
             ->select('uid', 'glossary_id', 'glossary_name')
-            ->from(self::TABLE)
+            ->from('tx_deepltranslate_glossary')
             ->where(
                 $queryBuilder->expr()->eq(
                     'pid',
@@ -157,17 +155,17 @@ final readonly class MigrateToMultilingualGlossaryWizard implements UpgradeWizar
      */
     private function collapseRecords(array $records): void
     {
-        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $connection = $this->connectionPool->getConnectionForTable('tx_deepltranslate_glossary');
         $keptRecord = array_shift($records);
         if ($keptRecord === null) {
             return;
         }
         foreach ($records as $record) {
-            $connection->delete(self::TABLE, ['uid' => (int)$record['uid']]);
+            $connection->delete('tx_deepltranslate_glossary', ['uid' => (int)$record['uid']]);
         }
 
         $connection->update(
-            self::TABLE,
+            'tx_deepltranslate_glossary',
             [
                 'glossary_id' => '',
                 'glossary_lastsync' => 0,

--- a/Classes/Upgrade/MigrateToMultilingualGlossaryWizard.php
+++ b/Classes/Upgrade/MigrateToMultilingualGlossaryWizard.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Upgrade;
+
+use DeepL\DeepLException;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
+
+/**
+ * Collapses the glossary records of the DeepL glossary API v2, which stored one glossary per
+ * language pair, into the single glossary record per folder the API v3 works with.
+ */
+#[UpgradeWizard(identifier: 'deepltranslateGlossary_migrateToMultilingualGlossary')]
+final readonly class MigrateToMultilingualGlossaryWizard implements UpgradeWizardInterface
+{
+    private const TABLE = 'tx_deepltranslate_glossary';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private GlossaryAPIV3ClientInterface $client,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate glossaries to the DeepL glossary API v3';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Collapses the glossary records of a folder into a single record, removes the'
+            . ' glossaries created with the DeepL glossary API v2 and detaches the folder, so'
+            . ' that the next synchronization publishes it through the API v3.';
+    }
+
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+
+        return (int)$queryBuilder
+            ->count('uid')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->neq(
+                    'source_lang',
+                    $queryBuilder->createNamedParameter('', Connection::PARAM_STR)
+                )
+            )
+            ->executeQuery()
+            ->fetchOne() > 0;
+    }
+
+    public function executeUpdate(): bool
+    {
+        foreach ($this->getFolderIdsToMigrate() as $pageId) {
+            $records = $this->getGlossaryRecordsOfFolder($pageId);
+            if ($records === []) {
+                continue;
+            }
+            $this->removeRemoteGlossaries($records);
+            $this->collapseRecords($records);
+        }
+
+        return true;
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getFolderIdsToMigrate(): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->select('pid')
+            ->distinct()
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->neq(
+                    'source_lang',
+                    $queryBuilder->createNamedParameter('', Connection::PARAM_STR)
+                )
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(static fn (array $row): int => (int)$row['pid'], $rows);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getGlossaryRecordsOfFolder(int $pageId): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+
+        return $queryBuilder
+            ->select('uid', 'glossary_id', 'glossary_name')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter($pageId, Connection::PARAM_INT)
+                )
+            )
+            ->orderBy('uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+
+    /**
+     * A glossary created through the API v2 covers a single language pair and cannot become a
+     * dictionary of a multilingual glossary, so it is removed instead of being converted.
+     *
+     * @param array<int, array<string, mixed>> $records
+     */
+    private function removeRemoteGlossaries(array $records): void
+    {
+        foreach ($records as $record) {
+            $glossaryId = (string)$record['glossary_id'];
+            if ($glossaryId === '') {
+                continue;
+            }
+            try {
+                $this->client->deleteGlossary($glossaryId);
+            } catch (DeepLException $exception) {
+                // Without a usable API key or connection the local migration still has to
+                // happen, otherwise the installation stays on the old structure entirely.
+                $this->logger->warning(sprintf(
+                    'Glossary "%s" could not be removed from DeepL during migration: %s',
+                    $glossaryId,
+                    $exception->getMessage()
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $records
+     */
+    private function collapseRecords(array $records): void
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $keptRecord = array_shift($records);
+        if ($keptRecord === null) {
+            return;
+        }
+        foreach ($records as $record) {
+            $connection->delete(self::TABLE, ['uid' => (int)$record['uid']]);
+        }
+
+        $connection->update(
+            self::TABLE,
+            [
+                'glossary_id' => '',
+                'glossary_lastsync' => 0,
+                'glossary_ready' => 0,
+                'source_lang' => '',
+                'target_lang' => '',
+            ],
+            ['uid' => (int)$keptRecord['uid']]
+        );
+    }
+}

--- a/Configuration/TCA/tx_deepltranslate_glossary.php
+++ b/Configuration/TCA/tx_deepltranslate_glossary.php
@@ -33,7 +33,7 @@ return [
         '1' => [
             'showitem' => '
             --div--;LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossary.tab.sync,
-            glossary_id,--palette--;;deepl',
+            glossary_id,--palette--;;deepl,dictionaries',
         ],
     ],
     'columns' => [
@@ -68,6 +68,15 @@ return [
                 'type' => 'check',
                 'readOnly' => true,
                 'searchable' => true,
+            ],
+        ],
+        'dictionaries' => [
+            'label' => 'LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossary.dictionaries',
+            'config' => [
+                'type' => 'inline',
+                'readOnly' => true,
+                'foreign_table' => 'tx_deepltranslate_glossarydictionary',
+                'foreign_field' => 'glossary',
             ],
         ],
     ],

--- a/Configuration/TCA/tx_deepltranslate_glossarydictionary.php
+++ b/Configuration/TCA/tx_deepltranslate_glossarydictionary.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'ctrl' => [
+        'title' => 'LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossarydictionary',
+        'label' => 'source_lang',
+        'label_alt' => 'target_lang',
+        'label_alt_force' => true,
+        'iconfile' => 'EXT:deepltranslate_glossary/Resources/Public/Icons/deepl-mode-aware.svg',
+        'default_sortby' => 'source_lang,target_lang',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'hideTable' => true,
+        // See the note on the parent table: synchronisation is meant to happen in live workspace
+        // only, the flag avoids the automatic TCA migration for inline child tables.
+        'versioningWS' => true,
+        'enablecolumns' => [],
+    ],
+    'columns' => [
+        'source_lang' => [
+            'label' => 'LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossarydictionary.source_lang',
+            'config' => [
+                'type' => 'input',
+                'readOnly' => true,
+                'searchable' => true,
+            ],
+        ],
+        'target_lang' => [
+            'label' => 'LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossarydictionary.target_lang',
+            'config' => [
+                'type' => 'input',
+                'readOnly' => true,
+                'searchable' => true,
+            ],
+        ],
+        'entry_count' => [
+            'label' => 'LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossarydictionary.entry_count',
+            'config' => [
+                'type' => 'number',
+                'readOnly' => true,
+            ],
+        ],
+        'in_sync' => [
+            'label' => 'LLL:EXT:deepltranslate_glossary/Resources/Private/Language/locallang.xlf:glossarydictionary.in_sync',
+            'config' => [
+                'type' => 'check',
+                'readOnly' => true,
+            ],
+        ],
+    ],
+    'types' => [
+        '1' => [
+            'showitem' => 'source_lang,target_lang,entry_count,in_sync',
+        ],
+    ],
+];

--- a/Documentation/Administration/Updates/UpgradeFrom4To5.rst
+++ b/Documentation/Administration/Updates/UpgradeFrom4To5.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 .. _upgrade4to5:
 
 ==================
@@ -47,3 +49,5 @@ classic-mode
 
 ..  _TER: https://extensions.typo3.org/extension/deepltranslate_glossary
 ..  _GITHUB_RELEASES: https://github.com/web-vision/deepltranslate-glossary/releases/
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Administration/Updates/UpgradeFrom5To6.rst
+++ b/Documentation/Administration/Updates/UpgradeFrom5To6.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 .. _upgrade5to6:
 
 ==================
@@ -35,3 +37,5 @@ classic-mode
 
 ..  _TER: https://extensions.typo3.org/extension/deepltranslate_glossary
 ..  _GITHUB_RELEASES: https://github.com/web-vision/deepltranslate-glossary/releases/
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/6.0/Breaking-OneGlossaryRecordPerFolder.rst
+++ b/Documentation/Changelog/6.0/Breaking-OneGlossaryRecordPerFolder.rst
@@ -44,10 +44,19 @@ Instances with synchronized glossaries, and any custom code querying
 Migration
 =========
 
-An upgrade wizard collapses the existing records of a folder into one glossary
-record with its dictionaries, removes the glossaries created with the API v2
-from the DeepL account and clears the local glossary id, so that the next
-synchronization creates the glossary through the API v3.
+An upgrade wizard collapses the existing records of a folder into a single
+glossary record and removes the glossaries created with the API v2 from the
+DeepL account, because a glossary of the API v2 covers one language pair and
+cannot become a dictionary of a multilingual glossary.
+
+The record is detached from its former glossary, so the next synchronization
+publishes the folder through the API v3 and creates its dictionaries. Run the
+synchronization of every glossary folder after the wizard, either through the
+backend or with :bash:`deepl:glossary:sync`.
+
+The wizard migrates the records even when no API key is configured or DeepL
+cannot be reached. The glossaries then stay on the DeepL account and have to be
+removed with :bash:`deepl:glossary:cleanup --all`.
 
 The columns :sql:`source_lang` and :sql:`target_lang` are kept on
 :sql:`tx_deepltranslate_glossary` until the wizard has run and are removed

--- a/Documentation/Changelog/6.0/Breaking-OneGlossaryRecordPerFolder.rst
+++ b/Documentation/Changelog/6.0/Breaking-OneGlossaryRecordPerFolder.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _breaking-oneglossaryrecordperfolder-1785196802:
 
 ==========================================
@@ -50,3 +52,5 @@ synchronization creates the glossary through the API v3.
 The columns :sql:`source_lang` and :sql:`target_lang` are kept on
 :sql:`tx_deepltranslate_glossary` until the wizard has run and are removed
 with the next major version.
+
+.. index:: Database, TCA, ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/6.0/Breaking-OneGlossaryRecordPerFolder.rst
+++ b/Documentation/Changelog/6.0/Breaking-OneGlossaryRecordPerFolder.rst
@@ -1,0 +1,52 @@
+..  _breaking-oneglossaryrecordperfolder-1785196802:
+
+==========================================
+Breaking: One glossary record per folder
+==========================================
+
+Description
+===========
+
+The DeepL glossary API v2 could only store a single language pair per
+glossary, so a glossary folder created one glossary record, and with it one
+remote glossary, for every language pair it contained.
+
+The glossary API v3 keeps a persistent glossary holding one dictionary per
+language pair. The structure follows that model:
+
+*   :sql:`tx_deepltranslate_glossary` holds exactly one record per glossary
+    folder, carrying the DeepL glossary id and the synchronization state
+*   the new table :sql:`tx_deepltranslate_glossarydictionary` holds one record
+    per language pair with its entry count and synchronization state
+
+The columns :sql:`source_lang` and :sql:`target_lang` therefore no longer
+describe a glossary but a dictionary.
+
+Impact
+======
+
+Custom code reading :sql:`tx_deepltranslate_glossary` to resolve a language
+pair no longer finds one glossary record per pair. A glossary folder now
+resolves to a single glossary id which is valid for every language pair the
+glossary contains.
+
+Reducing a folder to one remote glossary also lowers the number of glossaries
+counted against the limit of the DeepL account.
+
+Affected installations
+======================
+
+Instances with synchronized glossaries, and any custom code querying
+:sql:`tx_deepltranslate_glossary` directly.
+
+Migration
+=========
+
+An upgrade wizard collapses the existing records of a folder into one glossary
+record with its dictionaries, removes the glossaries created with the API v2
+from the DeepL account and clears the local glossary id, so that the next
+synchronization creates the glossary through the API v3.
+
+The columns :sql:`source_lang` and :sql:`target_lang` are kept on
+:sql:`tx_deepltranslate_glossary` until the wizard has run and are removed
+with the next major version.

--- a/Documentation/Changelog/6.0/Breaking-RaisedLowestSupportedDeepltranslateCoreVersion.rst
+++ b/Documentation/Changelog/6.0/Breaking-RaisedLowestSupportedDeepltranslateCoreVersion.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _breaking-1776026290:
 
 ===================================================================
@@ -27,3 +29,5 @@ Upgrade `EXT:deepltranslate_core` version along with `EXT:deepltranslate_glossar
     composer require -W \
       'web-vision/deepltranslate-core':'~6.0.0@dev' \
       'web-vision/deepltranslate-glossary':'~6.0.0@dev'
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/6.0/Breaking-RaisedLowestSupportedPhpVersion.rst
+++ b/Documentation/Changelog/6.0/Breaking-RaisedLowestSupportedPhpVersion.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _breaking-1776025649:
 
 =============================================
@@ -24,3 +26,5 @@ Migration
 
 Upgrade PHP version for the web-server and also when using composer and
 php commands, for example the `bin/typo3` command line tool.
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/6.0/Breaking-RemovedTYPO3V12Support.rst
+++ b/Documentation/Changelog/6.0/Breaking-RemovedTYPO3V12Support.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _breaking-1776025250:
 
 ===================================
@@ -35,3 +37,5 @@ Migration
 
 Upgrade TYPO3 to supported version for `6.x` beforehand or in the same step
 with upgrading/installing `EXT:deepltranslate_glossary`.
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/6.0/Deprecation-GlossaryApiV2Handling.rst
+++ b/Documentation/Changelog/6.0/Deprecation-GlossaryApiV2Handling.rst
@@ -1,0 +1,42 @@
+.. include:: /Includes.rst.txt
+
+..  _deprecation-glossaryapiv2handling-1785196804:
+
+======================================
+Deprecation: Glossary handling for v2
+======================================
+
+Description
+===========
+
+Everything handling the DeepL glossary API v2 is deprecated:
+
+*   :php:`\WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService`
+*   :php:`\WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV2Client`
+*   :php:`\WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV2ClientInterface`
+
+The extension synchronizes through
+:php:`\WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService` and the glossary
+API v3 instead. The synchronization command, the synchronization button of the
+backend, the listing and the cleanup command all use the API v3 now.
+
+Impact
+======
+
+The deprecated classes are not used by the extension any longer, but they are still
+functional. DeepL states that a glossary edited through the API v3 can no longer be
+queried correctly through the API v2, so both should not be mixed on the same glossary.
+
+Affected installations
+======================
+
+Instances with custom code calling the deprecated classes.
+
+Migration
+=========
+
+Use :php:`MultilingualGlossaryService::syncGlossary()` to synchronize a glossary folder and
+:php:`GlossaryAPIV3ClientInterface` to talk to the glossary API. There is no fallback to the
+API v2, fresh installations always use the API v3.
+
+.. index:: PHP-API, ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/6.0/Feature-AddedTYPO3v14Support.rst
+++ b/Documentation/Changelog/6.0/Feature-AddedTYPO3v14Support.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _feature-addedtypo3v14support-1777264756:
 
 ================================
@@ -15,3 +17,4 @@ Impact
 :guilabel:`web-vision/deepltranslate-glossary` can now be installed and used in
 :guilabel:`TYPO3 v14.3` instances.
 
+.. index:: ext:deepltranslate_glossary

--- a/Documentation/Changelog/6.0/Feature-CompletedGlossaryApiV3Client.rst
+++ b/Documentation/Changelog/6.0/Feature-CompletedGlossaryApiV3Client.rst
@@ -1,0 +1,48 @@
+..  _feature-completedglossaryapiv3client-1785196801:
+
+===============================================
+Feature: Completed glossary client for DeepL v3
+===============================================
+
+Description
+===========
+
+The client for the DeepL glossary API v3 covered creating, reading and merging
+glossaries only. The remaining endpoints of the multilingual glossary API are
+now available as well:
+
+*   replacing a single dictionary of a language pair
+*   removing a single dictionary from a glossary
+*   removing a whole glossary
+*   reading the entries of a dictionary
+
+Replacing a dictionary uses the replacing endpoint instead of the merging one.
+A term removed in TYPO3 would otherwise remain in the DeepL dictionary,
+because merging only ever adds or overwrites single terms.
+
+A failing API call no longer answers with a placeholder glossary carrying an
+empty glossary id. The original DeepL exception is rethrown instead, keeping
+its subclasses intact so that a glossary removed on the DeepL side stays
+distinguishable from other failures.
+
+Impact
+======
+
+A failed glossary API call is no longer indistinguishable from a successful
+one. Previously a caller could store an empty glossary id together with a
+fresh synchronization timestamp, which made a glossary folder look
+synchronized while no glossary existed at DeepL.
+
+Affected installations
+======================
+
+Instances using :guilabel:`EXT:deepltranslate_glossary` with a configured
+DeepL API key. The client is marked internal and not part of the public
+extension API, so no custom code is expected to call it directly.
+
+Migration
+=========
+
+No migration required. Custom code calling the internal client has to catch
+:php:`\DeepL\DeepLException` where it previously checked the returned glossary
+for an empty glossary id.

--- a/Documentation/Changelog/6.0/Feature-CompletedGlossaryApiV3Client.rst
+++ b/Documentation/Changelog/6.0/Feature-CompletedGlossaryApiV3Client.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _feature-completedglossaryapiv3client-1785196801:
 
 ===============================================
@@ -46,3 +48,5 @@ Migration
 No migration required. Custom code calling the internal client has to catch
 :php:`\DeepL\DeepLException` where it previously checked the returned glossary
 for an empty glossary id.
+
+.. index:: PHP-API, ext:deepltranslate_glossary

--- a/Documentation/Changelog/6.0/Important-SanitizedGlossaryTerms.rst
+++ b/Documentation/Changelog/6.0/Important-SanitizedGlossaryTerms.rst
@@ -1,0 +1,37 @@
+..  _important-sanitizedglossaryterms-1785196803:
+
+=====================================
+Important: Glossary terms are cleaned
+=====================================
+
+Description
+===========
+
+Glossary terms are trimmed before they are sent to DeepL, and a term pair is
+dropped when its source or its target is empty afterwards.
+
+DeepL rejects a term without non-whitespace characters and answers the whole
+request with an error. A single term an editor left unfilled would therefore
+abort the synchronization of an entire glossary folder.
+
+Impact
+======
+
+Surrounding whitespace of a term no longer reaches DeepL, so terms which
+differ in whitespace only are treated as the same term. Where trimming lets
+two source terms collapse into the same term, the last pair wins.
+
+A glossary folder synchronizes successfully even when single term pairs are
+incomplete. Those pairs are skipped silently instead of failing the folder.
+
+Affected installations
+======================
+
+Instances with glossary entries containing leading or trailing whitespace, or
+with incomplete term pairs.
+
+Migration
+=========
+
+No migration required. Synchronize the affected glossary folders to send the
+cleaned terms to DeepL.

--- a/Documentation/Changelog/6.0/Important-SanitizedGlossaryTerms.rst
+++ b/Documentation/Changelog/6.0/Important-SanitizedGlossaryTerms.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _important-sanitizedglossaryterms-1785196803:
 
 =====================================
@@ -35,3 +37,5 @@ Migration
 
 No migration required. Synchronize the affected glossary folders to send the
 cleaned terms to DeepL.
+
+.. index:: PHP-API, ext:deepltranslate_glossary

--- a/Documentation/Changelog/Changelog-6-combined.rst
+++ b/Documentation/Changelog/Changelog-6-combined.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _changelog-v6-byType:
 
 ===================
@@ -51,3 +53,5 @@ Important notes
     :glob:
 
     /Changelog/6.*/Important-*
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Changelog/Changelog-6.rst
+++ b/Documentation/Changelog/Changelog-6.rst
@@ -1,3 +1,5 @@
+.. include:: /Includes.rst.txt
+
 ..  _changelog-v6:
 
 ============
@@ -19,3 +21,5 @@ Also available
     :titlesonly:
 
     Changelog-6-combined
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Documentation/Editor/Index.rst
+++ b/Documentation/Editor/Index.rst
@@ -3,9 +3,12 @@
 Glossaries
 ==========
 
-You can define glossaries for your translations. Each glossary has a name, a source
-language and a target language. The name is made up of the page title and the target
-and source languages.
+You can define glossaries for your translations. A glossary folder holds exactly one
+glossary, which is registered once at DeepL and kept up to date afterwards. Its name is
+made up of the page title and the page id.
+
+The glossary contains one dictionary per language pair, listing how many terms that pair
+covers. So a single glossary serves every language combination its folder provides.
 
 ..  figure:: /Images/Editor/glossaries-list-view.png
     :alt: List view of glossary items

--- a/Documentation/Housekeeping/Index.rst
+++ b/Documentation/Housekeeping/Index.rst
@@ -33,7 +33,8 @@ Due to sync failures, it is useful to delete all DeepL glossaries.
 
 This command retrieves information about all glossaries or one glossary registered
 in the DeepL API and deletes them from the API. In addition, each glossary ID is
-checked against the database and if found, the database record is updated.
+checked against the database and if found, the database record is updated and the
+dictionaries describing the deleted glossary are removed with it.
 
 The command then checks the local database to see if any glossaries still have
 sync information, and cleans them up too.

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -2,6 +2,7 @@
     documentation project. It defines the text roles used across the manual.
 
 ..  role:: aspect (emphasis)
+..  role:: bash(code)
 ..  role:: html(code)
 ..  role:: js(code)
 ..  role:: php(code)

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,0 +1,17 @@
+..  This file is included at the very top of every ReST source file of this
+    documentation project. It defines the text roles used across the manual.
+
+..  role:: aspect (emphasis)
+..  role:: html(code)
+..  role:: js(code)
+..  role:: php(code)
+..  role:: rst(code)
+..  role:: sep(strong)
+..  role:: sql(code)
+..  role:: token(code)
+
+..  role:: typoscript(code)
+..  role:: ts(typoscript)
+    :class: typoscript
+
+..  role:: yaml(code)

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,7 +1,13 @@
+.. include:: /Includes.rst.txt
+
 :template: sitemap.html
+
+..  _sitemap:
 
 =======
 Sitemap
 =======
 
 .. The sitemap.html template will insert here the page tree automatically.
+
+.. index:: ext:deepltranslate_glossary, NotScanned

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -68,6 +68,24 @@
             <trans-unit id="glossary.glossary_ready">
                 <source>DeepL marked glossary as ready to use</source>
             </trans-unit>
+            <trans-unit id="glossary.dictionaries">
+                <source>Dictionaries</source>
+            </trans-unit>
+            <trans-unit id="glossarydictionary">
+                <source>Glossary dictionary</source>
+            </trans-unit>
+            <trans-unit id="glossarydictionary.source_lang">
+                <source>Source language</source>
+            </trans-unit>
+            <trans-unit id="glossarydictionary.target_lang">
+                <source>Target language</source>
+            </trans-unit>
+            <trans-unit id="glossarydictionary.entry_count">
+                <source>Entries</source>
+            </trans-unit>
+            <trans-unit id="glossarydictionary.in_sync">
+                <source>In sync with TYPO3</source>
+            </trans-unit>
             <trans-unit id="glossary.tab.sync">
                 <source>DeepL Sync</source>
             </trans-unit>

--- a/Tests/Functional/Client/GlossaryV3ClientTest.php
+++ b/Tests/Functional/Client/GlossaryV3ClientTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Client;
+
+use DeepL\GlossaryLanguagePair;
+use DeepL\MultilingualGlossaryDictionaryInfo;
+use DeepL\MultilingualGlossaryInfo;
+use PHPUnit\Framework\Attributes\Test;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+final class GlossaryV3ClientTest extends AbstractDeepLTestCase
+{
+    #[Test]
+    public function checkResponseFromGlossaryLanguagePairs(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        $response = $client->getGlossaryLanguagePairs();
+
+        $this->assertIsArray($response);
+        $this->assertContainsOnlyInstancesOf(GlossaryLanguagePair::class, $response);
+    }
+
+    #[Test]
+    public function checkResponseFromCreateGlossary(): void
+    {
+        /** @var GlossaryAPIV3ClientInterface $client */
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        /** @var MultilingualGlossaryService $glossaryService */
+        $glossaryService = $this->get(MultilingualGlossaryService::class);
+        $deEnDictionary = $glossaryService->createDictionary(
+            'de',
+            'en',
+            [
+                'Hallo' => 'Hello',
+                'Fachhochschule' => 'University of Applied Sciences',
+            ]
+        );
+        $glossaryName = 'Deepl-Client-Create-Function-Test:' . __FUNCTION__;
+        $response = $client->createGlossary(
+            $glossaryName,
+            [
+                $deEnDictionary,
+            ],
+        );
+
+        $this->assertInstanceOf(MultilingualGlossaryInfo::class, $response);
+        $this->assertIsString($response->glossaryId);
+        $this->assertEquals($glossaryName, $response->name);
+        $this->assertIsArray($response->dictionaries);
+        $this->assertCount(1, $response->dictionaries);
+        $dictionary = array_pop($response->dictionaries);
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryInfo::class, $dictionary);
+        $this->assertEquals('de', $dictionary->sourceLang);
+        $this->assertEquals('en', $dictionary->targetLang);
+        $this->assertInstanceOf(\DateTime::class, $response->creationTime);
+    }
+
+    #[Test]
+    public function glossaryIsUpdated(): void
+    {
+        /** @var GlossaryAPIV3ClientInterface $client */
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        /** @var MultilingualGlossaryService $glossaryService */
+        $glossaryService = $this->get(MultilingualGlossaryService::class);
+        $deEnDictionary = $glossaryService->createDictionary(
+            'de',
+            'en',
+            [
+                'Hallo' => 'Hello',
+                'Fachhochschule' => 'University of Applied Sciences',
+            ]
+        );
+        $glossaryName = 'Deepl-Client-Create-Function-Test:' . __FUNCTION__;
+        $createResponse = $client->createGlossary(
+            $glossaryName,
+            [
+                $deEnDictionary,
+            ],
+        );
+
+        /** @var non-empty-string $glossaryId */
+        $glossaryId = $createResponse->glossaryId;
+        $enFrDictionary = $glossaryService->createDictionary(
+            'en',
+            'fr',
+            [
+                'Hello' => 'Bonjour',
+                'University of Applied Sciences' => 'Université des sciences appliquées',
+            ]
+        );
+
+        $updateResponse = $client->updateGlossary(
+            $glossaryId,
+            [$enFrDictionary],
+        );
+        $this->assertInstanceOf(MultilingualGlossaryInfo::class, $updateResponse);
+        $this->assertIsString($updateResponse->glossaryId);
+        $this->assertEquals($glossaryName, $updateResponse->name);
+        $this->assertIsArray($updateResponse->dictionaries);
+        $this->assertCount(2, $updateResponse->dictionaries);
+        // @todo check if new dictionaries are always set to first array position or if this is random correct
+        $firstDictionary = array_pop($updateResponse->dictionaries);
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryInfo::class, $firstDictionary);
+        $this->assertEquals('en', $firstDictionary->sourceLang);
+        $this->assertEquals('fr', $firstDictionary->targetLang);
+        $secondDictionary = array_pop($updateResponse->dictionaries);
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryInfo::class, $secondDictionary);
+        $this->assertEquals('de', $secondDictionary->sourceLang);
+        $this->assertEquals('en', $secondDictionary->targetLang);
+        $this->assertInstanceOf(\DateTime::class, $updateResponse->creationTime);
+    }
+}

--- a/Tests/Functional/Client/GlossaryV3ClientTest.php
+++ b/Tests/Functional/Client/GlossaryV3ClientTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Client;
 
+use DeepL\DeepLException;
 use DeepL\GlossaryLanguagePair;
+use DeepL\GlossaryNotFoundException;
+use DeepL\MultilingualGlossaryDictionaryEntries;
 use DeepL\MultilingualGlossaryDictionaryInfo;
 use DeepL\MultilingualGlossaryInfo;
 use PHPUnit\Framework\Attributes\Test;
@@ -112,5 +115,126 @@ final class GlossaryV3ClientTest extends AbstractDeepLTestCase
         $this->assertEquals('de', $secondDictionary->sourceLang);
         $this->assertEquals('en', $secondDictionary->targetLang);
         $this->assertInstanceOf(\DateTime::class, $updateResponse->creationTime);
+    }
+
+    #[Test]
+    public function glossaryIsDeleted(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        $glossaryId = $this->createGlossaryWithDeEnDictionary(__FUNCTION__)->glossaryId;
+
+        $client->deleteGlossary($glossaryId);
+
+        // A deleted glossary must not resolve any longer. Without the exception the sync would
+        // keep a dangling glossary id in the local record.
+        $this->expectException(GlossaryNotFoundException::class);
+        $client->getGlossary($glossaryId);
+    }
+
+    #[Test]
+    public function replacingDictionaryDropsRemovedTerms(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        $glossaryService = $this->get(MultilingualGlossaryService::class);
+        $glossaryId = $this->createGlossaryWithDeEnDictionary(__FUNCTION__)->glossaryId;
+
+        $dictionaryInfo = $client->replaceDictionary(
+            $glossaryId,
+            $glossaryService->createDictionary(
+                'de',
+                'en',
+                [
+                    'Hallo' => 'Hello',
+                ]
+            )
+        );
+
+        // Replacing must not merge: the previously stored second entry has to be gone, otherwise
+        // a term deleted in TYPO3 would survive in the DeepL dictionary forever.
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryInfo::class, $dictionaryInfo);
+        $this->assertEquals('de', $dictionaryInfo->sourceLang);
+        $this->assertEquals('en', $dictionaryInfo->targetLang);
+        $this->assertEquals(1, $dictionaryInfo->entryCount);
+    }
+
+    #[Test]
+    public function dictionaryIsDeleted(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        $glossaryService = $this->get(MultilingualGlossaryService::class);
+        $glossaryId = $this->createGlossaryWithDeEnDictionary(__FUNCTION__)->glossaryId;
+        $client->replaceDictionary(
+            $glossaryId,
+            $glossaryService->createDictionary(
+                'en',
+                'fr',
+                [
+                    'Hello' => 'Bonjour',
+                ]
+            )
+        );
+
+        $client->deleteDictionary($glossaryId, 'en', 'fr');
+
+        $glossary = $client->getGlossary($glossaryId);
+        $this->assertCount(1, $glossary->dictionaries);
+        $remainingDictionary = array_pop($glossary->dictionaries);
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryInfo::class, $remainingDictionary);
+        $this->assertEquals('de', $remainingDictionary->sourceLang);
+        $this->assertEquals('en', $remainingDictionary->targetLang);
+    }
+
+    #[Test]
+    public function glossaryEntriesAreRetrieved(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        $glossaryId = $this->createGlossaryWithDeEnDictionary(__FUNCTION__)->glossaryId;
+
+        $entries = $client->getGlossaryEntries($glossaryId, 'de', 'en');
+
+        $this->assertIsArray($entries);
+        $this->assertContainsOnlyInstancesOf(MultilingualGlossaryDictionaryEntries::class, $entries);
+        $dictionary = array_shift($entries);
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryEntries::class, $dictionary);
+        $this->assertSame(
+            [
+                'Hallo' => 'Hello',
+                'Fachhochschule' => 'University of Applied Sciences',
+            ],
+            $dictionary->entries
+        );
+    }
+
+    #[Test]
+    public function unknownGlossaryRaisesExceptionInsteadOfEmptyGlossaryInfo(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+
+        // Guards the error contract: a failing call must not be answered with a placeholder
+        // MultilingualGlossaryInfo, which a caller cannot distinguish from a successful one.
+        // An unknown id is rejected as a bad request, only a deleted glossary raises the more
+        // specific GlossaryNotFoundException, see self::glossaryIsDeleted().
+        $this->expectException(DeepLException::class);
+        $client->getGlossary('4b1cbd1a-0000-0000-0000-000000000000');
+    }
+
+    private function createGlossaryWithDeEnDictionary(string $testName): MultilingualGlossaryInfo
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        $glossaryService = $this->get(MultilingualGlossaryService::class);
+
+        return $client->createGlossary(
+            'Deepl-Client-Create-Function-Test:' . $testName,
+            [
+                $glossaryService->createDictionary(
+                    'de',
+                    'en',
+                    [
+                        'Hallo' => 'Hello',
+                        'Fachhochschule' => 'University of Applied Sciences',
+                    ]
+                ),
+            ],
+        );
     }
 }

--- a/Tests/Functional/Command/GlossaryMaintenanceCommandTest.php
+++ b/Tests/Functional/Command/GlossaryMaintenanceCommandTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Command;
+
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
+use WebVision\Deepltranslate\Glossary\Command\GlossaryCleanupCommand;
+use WebVision\Deepltranslate\Glossary\Command\GlossaryListCommand;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+final class GlossaryMaintenanceCommandTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(rootPageId: 1),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/../Service/Fixtures/glossaryFolder.csv');
+        $this->setUpBackendUser(1);
+        $this->get(MultilingualGlossaryService::class)->syncGlossary(2);
+    }
+
+    #[Test]
+    public function listingShowsGlossaryWithItsDictionaries(): void
+    {
+        $commandTester = new CommandTester($this->get(GlossaryListCommand::class));
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $output = $commandTester->getDisplay();
+        // A v3 glossary carries its language pairs on the dictionaries, not on itself.
+        self::assertStringContainsString('en', $output);
+        self::assertStringContainsString('de', $output);
+        self::assertStringContainsString($this->fetchGlossaryId(), $output);
+    }
+
+    #[Test]
+    public function cleanupRemovesEveryGlossaryFromTheAccount(): void
+    {
+        $client = $this->get(GlossaryAPIV3ClientInterface::class);
+        self::assertNotSame([], $client->getAllGlossaries());
+        $commandTester = new CommandTester($this->get(GlossaryCleanupCommand::class));
+        $commandTester->setInputs(['yes', 'yes']);
+
+        $exitCode = $commandTester->execute(['--all' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame([], $client->getAllGlossaries());
+        // The local record must not keep pointing at a glossary which no longer exists.
+        self::assertSame('', $this->fetchGlossaryId());
+        self::assertSame(0, $this->countDictionaryRecords());
+    }
+
+    private function fetchGlossaryId(): string
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossary');
+
+        return (string)$queryBuilder
+            ->select('glossary_id')
+            ->from('tx_deepltranslate_glossary')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter(2, Connection::PARAM_INT)
+                )
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function countDictionaryRecords(): int
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossarydictionary');
+
+        return (int)$queryBuilder
+            ->count('uid')
+            ->from('tx_deepltranslate_glossarydictionary')
+            ->executeQuery()
+            ->fetchOne();
+    }
+}

--- a/Tests/Functional/Command/GlossarySyncCommandTest.php
+++ b/Tests/Functional/Command/GlossarySyncCommandTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Command;
+
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use WebVision\Deepltranslate\Glossary\Command\GlossarySyncCommand;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+final class GlossarySyncCommandTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(rootPageId: 1),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/../Service/Fixtures/glossaryFolder.csv');
+        $this->setUpBackendUser(1);
+    }
+
+    #[Test]
+    public function syncingASinglePageCreatesTheGlossary(): void
+    {
+        $commandTester = new CommandTester($this->get(GlossarySyncCommand::class));
+
+        $exitCode = $commandTester->execute(['--pageId' => '2']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $glossaries = $this->fetchGlossaryRecords();
+        self::assertCount(1, $glossaries);
+        self::assertNotSame('', $glossaries[0]['glossary_id']);
+        // Proves the command went through the API v3 path: only that one stores dictionaries.
+        self::assertSame(1, $this->countDictionaryRecords());
+    }
+
+    #[Test]
+    public function syncingAllGlossaryFoldersCreatesTheGlossary(): void
+    {
+        $commandTester = new CommandTester($this->get(GlossarySyncCommand::class));
+
+        $exitCode = $commandTester->execute([]);
+
+        // The folder is picked up through its glossary module assignment.
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $glossaries = $this->fetchGlossaryRecords();
+        self::assertCount(1, $glossaries);
+        self::assertNotSame('', $glossaries[0]['glossary_id']);
+        self::assertSame(1, $this->countDictionaryRecords());
+    }
+
+    private function countDictionaryRecords(): int
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossarydictionary');
+
+        return (int)$queryBuilder
+            ->count('uid')
+            ->from('tx_deepltranslate_glossarydictionary')
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchGlossaryRecords(): array
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossary');
+
+        return $queryBuilder
+            ->select('uid', 'glossary_id', 'glossary_ready')
+            ->from('tx_deepltranslate_glossary')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter(2, Connection::PARAM_INT)
+                )
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}

--- a/Tests/Functional/Domain/Repository/Fixtures/syncedGlossary.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/syncedGlossary.csv
@@ -1,0 +1,11 @@
+pages
+,"uid","pid","doktype","title","module","sys_language_uid","l10n_parent","slug"
+,1,0,1,"Deepl-Functional-Test","",0,0,"/"
+,2,1,254,"Glossary","glossary",0,0,""
+tx_deepltranslate_glossary
+,"uid","pid","glossary_id","glossary_name","glossary_lastsync","glossary_ready"
+,1,2,"3f2b0000-0000-0000-0000-000000000001","Glossary [2]",1700000000,1
+tx_deepltranslate_glossarydictionary
+,"uid","pid","glossary","source_lang","target_lang","entry_count","in_sync"
+,1,2,1,"en","de",2,1
+,2,2,1,"en","fr",1,1

--- a/Tests/Functional/Domain/Repository/GlossaryLookupTest.php
+++ b/Tests/Functional/Domain/Repository/GlossaryLookupTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Domain\Repository;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use WebVision\Deepltranslate\Core\Domain\Dto\CurrentPage;
+use WebVision\Deepltranslate\Glossary\Domain\Repository\GlossaryRepository;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+/**
+ * A glossary is valid for every language pair its dictionaries cover, so resolving a pair has to
+ * go through the dictionaries instead of the glossary record itself.
+ */
+final class GlossaryLookupTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(rootPageId: 1),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/syncedGlossary.csv');
+    }
+
+    /**
+     * @return \Generator<string, array{sourceLanguage: string, targetLanguage: string}>
+     */
+    public static function coveredLanguagePairs(): \Generator
+    {
+        yield 'first dictionary of the glossary' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'de',
+        ];
+        yield 'second dictionary of the same glossary' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'fr',
+        ];
+        yield 'language code is matched case insensitively' => [
+            'sourceLanguage' => 'EN',
+            'targetLanguage' => 'DE',
+        ];
+        yield 'regional target falls back to its base language' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'de-AT',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('coveredLanguagePairs')]
+    public function glossaryIsResolvedForEveryCoveredPair(string $sourceLanguage, string $targetLanguage): void
+    {
+        $subject = $this->get(GlossaryRepository::class);
+
+        $glossary = $subject->getGlossaryBySourceAndTarget(
+            $sourceLanguage,
+            $targetLanguage,
+            new CurrentPage(2, 'Glossary')
+        );
+
+        self::assertSame('3f2b0000-0000-0000-0000-000000000001', $glossary->glossaryId);
+        self::assertTrue($glossary->ready);
+    }
+
+    #[Test]
+    public function pairWithoutDictionaryResolvesNoGlossary(): void
+    {
+        $subject = $this->get(GlossaryRepository::class);
+
+        $glossary = $subject->getGlossaryBySourceAndTarget(
+            'en',
+            'it',
+            new CurrentPage(2, 'Glossary')
+        );
+
+        self::assertSame('', $glossary->glossaryId);
+        self::assertFalse($glossary->ready);
+    }
+}

--- a/Tests/Functional/Regression/GlossaryRegressionTest.php
+++ b/Tests/Functional/Regression/GlossaryRegressionTest.php
@@ -7,9 +7,8 @@ namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Regression;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use WebVision\Deepltranslate\Glossary\Service\DeeplGlossaryService;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
 use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
 
 final class GlossaryRegressionTest extends AbstractDeepLTestCase
@@ -73,10 +72,8 @@ final class GlossaryRegressionTest extends AbstractDeepLTestCase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/glossary.csv');
 
         $this->setUpBackendUser(1);
-        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
-            ->createFromUserPreferences($GLOBALS['BE_USER']);
-        GeneralUtility::makeInstance(DeeplGlossaryService::class)
-            ->syncGlossaries(2);
+        $this->get(MultilingualGlossaryService::class)
+            ->syncGlossary(2);
     }
 
     #[Test]

--- a/Tests/Functional/Schema/Fixtures/glossaryWithDictionaries.csv
+++ b/Tests/Functional/Schema/Fixtures/glossaryWithDictionaries.csv
@@ -1,0 +1,7 @@
+"tx_deepltranslate_glossary",,,,,,
+,"uid","pid","glossary_id","glossary_name","glossary_lastsync","glossary_ready"
+,1,2,"3f2b0000-0000-0000-0000-000000000001","Acme Glossary",1700000000,1
+"tx_deepltranslate_glossarydictionary",,,,,,
+,"uid","pid","glossary","source_lang","target_lang","entry_count","in_sync"
+,1,2,1,"de","en",2,1
+,2,2,1,"en","fr",1,0

--- a/Tests/Functional/Schema/GlossaryDictionaryTableTest.php
+++ b/Tests/Functional/Schema/GlossaryDictionaryTableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Schema;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+/**
+ * A glossary folder maps to exactly one DeepL glossary holding one dictionary per language pair.
+ * The language pair therefore lives on the dictionary records, no longer on the glossary itself.
+ */
+final class GlossaryDictionaryTableTest extends AbstractDeepLTestCase
+{
+    #[Test]
+    public function dictionariesAreStoredForOneGlossary(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/glossaryWithDictionaries.csv');
+
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossarydictionary');
+        $dictionaries = $queryBuilder
+            ->select('source_lang', 'target_lang', 'entry_count', 'in_sync')
+            ->from('tx_deepltranslate_glossarydictionary')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'glossary',
+                    $queryBuilder->createNamedParameter(1, Connection::PARAM_INT)
+                )
+            )
+            ->orderBy('uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        self::assertCount(2, $dictionaries);
+        self::assertSame('de', $dictionaries[0]['source_lang']);
+        self::assertSame('en', $dictionaries[0]['target_lang']);
+        self::assertSame(2, (int)$dictionaries[0]['entry_count']);
+        self::assertSame(1, (int)$dictionaries[0]['in_sync']);
+        self::assertSame('en', $dictionaries[1]['source_lang']);
+        self::assertSame('fr', $dictionaries[1]['target_lang']);
+        self::assertSame(0, (int)$dictionaries[1]['in_sync']);
+    }
+
+    #[Test]
+    public function glossaryRecordCarriesNoLanguagePair(): void
+    {
+        $glossarySchema = $this->get(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossary')
+            ->createSchemaManager()
+            ->listTableColumns('tx_deepltranslate_glossary');
+        $columns = array_keys($glossarySchema);
+
+        // The glossary record is the single entry point per folder, so it keeps the DeepL id and
+        // the synchronisation state only.
+        self::assertContains('glossary_id', $columns);
+        self::assertContains('glossary_ready', $columns);
+        self::assertContains('dictionaries', $columns);
+    }
+}

--- a/Tests/Functional/Service/Fixtures/glossaryFolder.csv
+++ b/Tests/Functional/Service/Fixtures/glossaryFolder.csv
@@ -1,0 +1,14 @@
+pages
+,"uid","pid","doktype","title","module","sys_language_uid","l10n_parent","slug"
+,1,0,1,"Deepl-Functional-Test","",0,0,"/"
+,2,1,254,"Glossary","glossary",0,0,""
+,3,1,254,"Glossar","glossary",1,2,""
+"be_users"
+,"uid","pid","tstamp","username","password","admin","disable","starttime","endtime","options","crdate","workspace_perms","deleted","TSconfig","lastlogin","workspace_id"
+,1,0,1366642540,"admin","$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1,0,0,0,0,1366642540,1,0,,1371033743,0
+tx_deepltranslate_glossaryentry
+,"uid","pid","term","sys_language_uid","l10n_parent"
+,1,2,"glossary term",0,0
+,2,2,"Glossareintrag",1,1
+,3,2,"proton beam",0,0
+,4,2,"Protonenstrahl",1,3

--- a/Tests/Functional/Service/MultilingualGlossaryServiceTest.php
+++ b/Tests/Functional/Service/MultilingualGlossaryServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Service;
+
+use DeepL\DeepLException;
+use DeepL\MultilingualGlossaryDictionaryEntries;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+final class MultilingualGlossaryServiceTest extends AbstractDeepLTestCase
+{
+    /**
+     * @return \Generator<string, array{
+     *     sourceLanguage: non-empty-string,
+     *     targetLanguage: non-empty-string,
+     *     dictionaryEntries: array<string, string>,
+     *     expectedEntryCount: int,
+     * }>
+     */
+    public static function dictionaryCreator(): \Generator
+    {
+        yield 'EN - DE Dictionary' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'de',
+            'dictionaryEntries' => [
+                'University of Applied Sciences' => 'Fachhochschule',
+            ],
+            'expectedEntryCount' => 1,
+        ];
+        yield 'DE-EN Dictionary' => [
+            'sourceLanguage' => 'de',
+            'targetLanguage' => 'en',
+            'dictionaryEntries' => [
+                'Hallo' => 'Hello',
+                'Fachhochschule' => 'University of Applied Sciences',
+            ],
+            'expectedEntryCount' => 2,
+        ];
+    }
+
+    /**
+     * @param non-empty-string $sourceLanguage
+     * @param non-empty-string$targetLanguage
+     * @param array<string, string> $dictionaryEntries
+     */
+    #[Test]
+    #[DataProvider('dictionaryCreator')]
+    public function dictionaryIsCreated(
+        string $sourceLanguage,
+        string $targetLanguage,
+        array $dictionaryEntries,
+        int $expectedEntryCount,
+    ): void {
+        /** @var MultilingualGlossaryService $subject */
+        $subject = $this->get(MultilingualGlossaryService::class);
+        $dictionary = $subject->createDictionary(
+            $sourceLanguage,
+            $targetLanguage,
+            $dictionaryEntries
+        );
+        $this->assertInstanceOf(MultilingualGlossaryDictionaryEntries::class, $dictionary);
+        $this->assertIsArray($dictionary->entries);
+        $this->assertCount($expectedEntryCount, $dictionary->entries);
+    }
+
+    /**
+     * @return \Generator<string, array{
+     *     sourceLanguage: non-empty-string,
+     *     targetLanguage: non-empty-string,
+     *     dictionaryEntries: array<string, string>,
+     *     expectedException: class-string<\Throwable>,
+     *     expectedExceptionMessage: string
+     * }>
+     */
+    public static function dictionaryWithInvalidEntries(): \Generator
+    {
+        yield 'EN - DE Dictionary with empty entries' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'de',
+            'dictionaryEntries' => [],
+            'expectedException' => DeepLException::class,
+            'expectedExceptionMessage' => 'Input contains no entries',
+        ];
+
+        yield 'EN - DE Dictionary with whitespace only source entry' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'de',
+            'dictionaryEntries' => [
+                '      ' => 'Ziel',
+            ],
+            'expectedException' => DeepLException::class,
+            'expectedExceptionMessage' => 'Term "      " contains no non-whitespace characters',
+        ];
+
+        yield 'EN - DE Dictionary with whitespace only target entry' => [
+            'sourceLanguage' => 'en',
+            'targetLanguage' => 'de',
+            'dictionaryEntries' => [
+                'source' => '      ',
+            ],
+            'expectedException' => DeepLException::class,
+            'expectedExceptionMessage' => 'Term "      " contains no non-whitespace characters',
+        ];
+    }
+
+    /**
+     * @param non-empty-string $sourceLanguage
+     * @param non-empty-string $targetLanguage
+     * @param array<string, string> $dictionaryEntries
+     * @param class-string<\Throwable> $expectedException
+     */
+    #[Test]
+    #[DataProvider('dictionaryWithInvalidEntries')]
+    public function invalidEntriesCreateException(
+        string $sourceLanguage,
+        string $targetLanguage,
+        array $dictionaryEntries,
+        string $expectedException,
+        string $expectedExceptionMessage,
+    ): void {
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $subject = $this->get(MultilingualGlossaryService::class);
+        $subject->createDictionary(
+            $sourceLanguage,
+            $targetLanguage,
+            $dictionaryEntries
+        );
+    }
+}

--- a/Tests/Functional/Service/MultilingualGlossaryServiceTest.php
+++ b/Tests/Functional/Service/MultilingualGlossaryServiceTest.php
@@ -69,6 +69,62 @@ final class MultilingualGlossaryServiceTest extends AbstractDeepLTestCase
 
     /**
      * @return \Generator<string, array{
+     *     dictionaryEntries: array<string, string>,
+     *     expectedEntries: array<string, string>,
+     * }>
+     */
+    public static function dictionaryWithUncleanEntries(): \Generator
+    {
+        yield 'surrounding whitespace is trimmed' => [
+            'dictionaryEntries' => [
+                '  Hallo  ' => "\tHello\n",
+            ],
+            'expectedEntries' => [
+                'Hallo' => 'Hello',
+            ],
+        ];
+        yield 'pair with whitespace only source is dropped' => [
+            'dictionaryEntries' => [
+                'Hallo' => 'Hello',
+                '      ' => 'Ziel',
+            ],
+            'expectedEntries' => [
+                'Hallo' => 'Hello',
+            ],
+        ];
+        yield 'pair with whitespace only target is dropped' => [
+            'dictionaryEntries' => [
+                'Hallo' => 'Hello',
+                'Fachhochschule' => '   ',
+            ],
+            'expectedEntries' => [
+                'Hallo' => 'Hello',
+            ],
+        ];
+    }
+
+    /**
+     * A single term left unfilled by an editor must not abort the synchronisation of a whole
+     * glossary folder, so unusable pairs are dropped instead of rejected.
+     *
+     * @param array<string, string> $dictionaryEntries
+     * @param array<string, string> $expectedEntries
+     */
+    #[Test]
+    #[DataProvider('dictionaryWithUncleanEntries')]
+    public function uncleanEntriesAreSanitized(
+        array $dictionaryEntries,
+        array $expectedEntries,
+    ): void {
+        $subject = $this->get(MultilingualGlossaryService::class);
+
+        $dictionary = $subject->createDictionary('de', 'en', $dictionaryEntries);
+
+        self::assertSame($expectedEntries, $dictionary->entries);
+    }
+
+    /**
+     * @return \Generator<string, array{
      *     sourceLanguage: non-empty-string,
      *     targetLanguage: non-empty-string,
      *     dictionaryEntries: array<string, string>,
@@ -86,24 +142,25 @@ final class MultilingualGlossaryServiceTest extends AbstractDeepLTestCase
             'expectedExceptionMessage' => 'Input contains no entries',
         ];
 
-        yield 'EN - DE Dictionary with whitespace only source entry' => [
+        // The unusable pair is dropped, which leaves no entry at all behind.
+        yield 'EN - DE Dictionary emptied by a whitespace only source entry' => [
             'sourceLanguage' => 'en',
             'targetLanguage' => 'de',
             'dictionaryEntries' => [
                 '      ' => 'Ziel',
             ],
             'expectedException' => DeepLException::class,
-            'expectedExceptionMessage' => 'Term "      " contains no non-whitespace characters',
+            'expectedExceptionMessage' => 'Input contains no entries',
         ];
 
-        yield 'EN - DE Dictionary with whitespace only target entry' => [
+        yield 'EN - DE Dictionary emptied by a whitespace only target entry' => [
             'sourceLanguage' => 'en',
             'targetLanguage' => 'de',
             'dictionaryEntries' => [
                 'source' => '      ',
             ],
             'expectedException' => DeepLException::class,
-            'expectedExceptionMessage' => 'Term "      " contains no non-whitespace characters',
+            'expectedExceptionMessage' => 'Input contains no entries',
         ];
     }
 

--- a/Tests/Functional/Service/MultilingualGlossarySyncTest.php
+++ b/Tests/Functional/Service/MultilingualGlossarySyncTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use WebVision\Deepltranslate\Glossary\Client\GlossaryAPIV3ClientInterface;
+use WebVision\Deepltranslate\Glossary\Service\MultilingualGlossaryService;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+
+/**
+ * Synchronising a glossary folder has to end up with exactly one persistent DeepL glossary
+ * holding one dictionary per language pair, see the glossary API v3.
+ */
+final class MultilingualGlossarySyncTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(rootPageId: 1),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/glossaryFolder.csv');
+
+        // Resolving the localizations of a glossary folder goes through
+        // TranslationConfigurationProvider, which requires an authenticated backend user.
+        $this->setUpBackendUser(1);
+    }
+
+    #[Test]
+    public function firstSyncCreatesOneGlossaryForTheFolder(): void
+    {
+        $subject = $this->get(MultilingualGlossaryService::class);
+
+        $subject->syncGlossary(2);
+
+        $glossaries = $this->fetchGlossaryRecords();
+        self::assertCount(1, $glossaries, 'A folder maps to exactly one DeepL glossary.');
+        self::assertNotSame('', $glossaries[0]['glossary_id']);
+        self::assertSame(1, (int)$glossaries[0]['glossary_ready']);
+        self::assertGreaterThan(0, (int)$glossaries[0]['glossary_lastsync']);
+    }
+
+    #[Test]
+    public function firstSyncStoresDictionaryPerLanguagePair(): void
+    {
+        $subject = $this->get(MultilingualGlossaryService::class);
+
+        $subject->syncGlossary(2);
+
+        $dictionaries = $this->fetchDictionaryRecords();
+        self::assertCount(1, $dictionaries);
+        self::assertSame('en', $dictionaries[0]['source_lang']);
+        self::assertSame('de', $dictionaries[0]['target_lang']);
+        self::assertSame(2, (int)$dictionaries[0]['entry_count']);
+        self::assertSame(1, (int)$dictionaries[0]['in_sync']);
+    }
+
+    #[Test]
+    public function repeatedSyncKeepsTheSameGlossary(): void
+    {
+        $subject = $this->get(MultilingualGlossaryService::class);
+        $subject->syncGlossary(2);
+        $firstGlossaryId = $this->fetchGlossaryRecords()[0]['glossary_id'];
+
+        $subject->syncGlossary(2);
+
+        // A persistent glossary is edited in place, it must not be replaced on every sync.
+        $glossaries = $this->fetchGlossaryRecords();
+        self::assertCount(1, $glossaries);
+        self::assertSame($firstGlossaryId, $glossaries[0]['glossary_id']);
+    }
+
+    #[Test]
+    public function syncRecreatesGlossaryDeletedOnDeeplSide(): void
+    {
+        $subject = $this->get(MultilingualGlossaryService::class);
+        $subject->syncGlossary(2);
+        $firstGlossaryId = $this->fetchGlossaryRecords()[0]['glossary_id'];
+        $this->get(GlossaryAPIV3ClientInterface::class)->deleteGlossary($firstGlossaryId);
+
+        $subject->syncGlossary(2);
+
+        $glossaries = $this->fetchGlossaryRecords();
+        self::assertCount(1, $glossaries);
+        self::assertNotSame('', $glossaries[0]['glossary_id']);
+        self::assertNotSame($firstGlossaryId, $glossaries[0]['glossary_id']);
+        self::assertSame(1, (int)$glossaries[0]['glossary_ready']);
+    }
+
+    #[Test]
+    public function folderWithoutUsableEntriesDropsTheGlossary(): void
+    {
+        $subject = $this->get(MultilingualGlossaryService::class);
+        $subject->syncGlossary(2);
+        $this->get(ConnectionPool::class)
+            ->getConnectionForTable('tx_deepltranslate_glossaryentry')
+            ->delete('tx_deepltranslate_glossaryentry', ['pid' => 2]);
+
+        $subject->syncGlossary(2);
+
+        // Without a single term pair there is nothing left to translate with, so the remote
+        // glossary is removed instead of being left behind as an orphan.
+        $glossaries = $this->fetchGlossaryRecords();
+        self::assertCount(1, $glossaries);
+        self::assertSame('', $glossaries[0]['glossary_id']);
+        self::assertSame(0, (int)$glossaries[0]['glossary_ready']);
+        self::assertSame([], $this->fetchDictionaryRecords());
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchGlossaryRecords(): array
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossary');
+
+        return $queryBuilder
+            ->select('uid', 'glossary_id', 'glossary_name', 'glossary_lastsync', 'glossary_ready')
+            ->from('tx_deepltranslate_glossary')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter(2, Connection::PARAM_INT)
+                )
+            )
+            ->orderBy('uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchDictionaryRecords(): array
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossarydictionary');
+
+        return $queryBuilder
+            ->select('source_lang', 'target_lang', 'entry_count', 'in_sync')
+            ->from('tx_deepltranslate_glossarydictionary')
+            ->orderBy('source_lang')
+            ->addOrderBy('target_lang')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}

--- a/Tests/Functional/Upgrade/Fixtures/perPairGlossaries.csv
+++ b/Tests/Functional/Upgrade/Fixtures/perPairGlossaries.csv
@@ -1,0 +1,11 @@
+pages
+,"uid","pid","doktype","title","module","sys_language_uid","l10n_parent","slug"
+,1,0,1,"Deepl-Functional-Test","",0,0,"/"
+,2,1,254,"Glossary","glossary",0,0,""
+,5,1,254,"Second Glossary","glossary",0,0,""
+tx_deepltranslate_glossary
+,"uid","pid","glossary_id","glossary_name","glossary_lastsync","glossary_ready","source_lang","target_lang"
+,1,2,"v2-en-de","Glossary: en => de",1700000000,1,"en","de"
+,2,2,"v2-en-fr","Glossary: en => fr",1700000000,1,"en","fr"
+,3,2,"","Glossary: en => it",0,0,"en","it"
+,4,5,"v2-de-en","Second: de => en",1700000000,1,"de","en"

--- a/Tests/Functional/Upgrade/MigrateToMultilingualGlossaryWizardTest.php
+++ b/Tests/Functional/Upgrade/MigrateToMultilingualGlossaryWizardTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Glossary\Tests\Functional\Upgrade;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use WebVision\Deepltranslate\Glossary\Tests\Functional\AbstractDeepLTestCase;
+use WebVision\Deepltranslate\Glossary\Upgrade\MigrateToMultilingualGlossaryWizard;
+
+/**
+ * The glossary API v2 stored one glossary per language pair. Those records have to collapse
+ * into the single glossary record per folder the API v3 works with.
+ */
+final class MigrateToMultilingualGlossaryWizardTest extends AbstractDeepLTestCase
+{
+    #[Test]
+    public function migrationIsNecessaryForPerPairRecords(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/perPairGlossaries.csv');
+        $subject = $this->get(MigrateToMultilingualGlossaryWizard::class);
+
+        self::assertTrue($subject->updateNecessary());
+    }
+
+    #[Test]
+    public function everyFolderKeepsExactlyOneGlossaryRecord(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/perPairGlossaries.csv');
+        $subject = $this->get(MigrateToMultilingualGlossaryWizard::class);
+
+        self::assertTrue($subject->executeUpdate());
+
+        self::assertCount(1, $this->fetchGlossaryRecords(2));
+        self::assertCount(1, $this->fetchGlossaryRecords(5));
+    }
+
+    #[Test]
+    public function migratedRecordIsDetachedFromItsFormerGlossary(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/perPairGlossaries.csv');
+        $subject = $this->get(MigrateToMultilingualGlossaryWizard::class);
+
+        $subject->executeUpdate();
+
+        // The glossary ids belong to glossaries created through the API v2, so the record must
+        // not keep them. The next synchronisation publishes the folder through the API v3.
+        $glossary = $this->fetchGlossaryRecords(2)[0];
+        self::assertSame('', $glossary['glossary_id']);
+        self::assertSame(0, (int)$glossary['glossary_ready']);
+        self::assertSame(0, (int)$glossary['glossary_lastsync']);
+        self::assertSame('', $glossary['source_lang']);
+        self::assertSame('', $glossary['target_lang']);
+    }
+
+    #[Test]
+    public function migrationIsNotRepeated(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/perPairGlossaries.csv');
+        $subject = $this->get(MigrateToMultilingualGlossaryWizard::class);
+        $subject->executeUpdate();
+
+        self::assertFalse($subject->updateNecessary());
+    }
+
+    #[Test]
+    public function migrationIsNotNecessaryWithoutAnyGlossary(): void
+    {
+        $subject = $this->get(MigrateToMultilingualGlossaryWizard::class);
+
+        self::assertFalse($subject->updateNecessary());
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchGlossaryRecords(int $pageId): array
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_deepltranslate_glossary');
+
+        return $queryBuilder
+            ->select('uid', 'glossary_id', 'glossary_name', 'glossary_lastsync', 'glossary_ready', 'source_lang', 'target_lang')
+            ->from('tx_deepltranslate_glossary')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter($pageId, \TYPO3\CMS\Core\Database\Connection::PARAM_INT)
+                )
+            )
+            ->orderBy('uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
 		"typo3/cms-styleguide": "~13.4.28@dev || ~14.3.0@dev",
 		"typo3/cms-tstemplate": "~13.4.28@dev || ~14.3.0@dev",
 		"typo3/cms-workspaces": "~13.4.28@dev || ~14.3.0@dev",
+		"typo3/minimal": "^14",
 		"typo3/testing-framework": "^9.5.0",
 		"vaimo/composer-patches": "^6.0.1",
 		"web-vision/deepl-base": "~2.0.0@dev"

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -10,8 +10,18 @@ create table tx_deepltranslate_glossary
     glossary_lastsync int(11) unsigned default '0' not null,
     glossary_id       varchar(60)      default '',
     glossary_name     varchar(255)     default ''  not null,
+    -- The language pair moved to `tx_deepltranslate_glossarydictionary` with glossary API v3.
+    -- Both columns are kept until the upgrade wizard has migrated existing installations and
+    -- are removed with the next major version.
     source_lang       varchar(10)      default ''  not null,
     target_lang       varchar(10)      default ''  not null
+);
+
+-- Only the parent pointer needs an explicit definition, every other column of this table is
+-- derived from its TCA.
+create table tx_deepltranslate_glossarydictionary
+(
+    glossary int(11) unsigned default '0' not null
 );
 
 CREATE TABLE pages


### PR DESCRIPTION
## Why

The DeepL glossary API v2 only knows immutable glossaries covering a
single language pair. Changing one term meant deleting and recreating
the glossary, and a folder with several translations produced one
remote glossary per pair.

The API v3 keeps a persistent glossary holding one dictionary per
language pair, which can be edited in place. This moves the extension
over to it.

## What changes

**One glossary per folder.** `tx_deepltranslate_glossary` keeps exactly
one record per glossary folder, carrying the DeepL glossary id and the
synchronization state. The new table
`tx_deepltranslate_glossarydictionary` holds one record per language
pair with its entry count. A folder therefore occupies one glossary of
the account instead of one per pair.

**Editing instead of recreating.** A glossary is created once and kept
up to date afterwards, so its id stays stable and pages referencing it
keep working. Each pair is written with the replacing endpoint rather
than the merging one, otherwise a term removed in TYPO3 would survive
at DeepL forever. A pair no longer configured is removed, a glossary
deleted on the DeepL side is published again, and a folder without any
usable term pair drops its glossary instead of leaving an orphan.

**Resolving a glossary** goes through the dictionaries, because a v3
glossary is valid for every pair its dictionaries cover.

**Terms are cleaned** before they are sent. DeepL rejects a term
without non-whitespace characters and fails the whole request, so a
single term an editor left unfilled aborted the synchronization of an
entire folder. Such pairs are dropped instead.

**Failures are no longer silent.** The client answered a failing call
with a placeholder glossary carrying an empty id, which a caller could
not tell apart from success and stored together with a fresh
synchronization timestamp. The original DeepL exception is rethrown
now, keeping its subclasses intact.

**Every entry point** uses the API v3: the synchronization command, the
backend synchronization button, the listing and the cleanup command.
Handling for the API v2 stays in place, marked deprecated, and is no
longer used internally. There is no fallback; fresh installations
always use the API v3.

## Migration

An upgrade wizard collapses the per-pair records of a folder into a
single record and removes the glossaries created with the API v2 from
the account, because such a glossary covers one pair and cannot become
a dictionary of a multilingual glossary. The record is detached, so the
next synchronization publishes the folder through the API v3.

The wizard also migrates when DeepL cannot be reached, otherwise an
instance without a configured key would stay on the old structure. The
affected glossaries are logged and can be removed with
`deepl:glossary:cleanup --all` later.

Run the synchronization of every glossary folder after the wizard.

## Testing

| Suite | TYPO3 13.4 | TYPO3 14.3.5 |
| --- | --- | --- |
| functional (sqlite, mock server) | 57 tests, 183 assertions | 57 tests, 183 assertions |
| unit | 8 tests | 8 tests |
| phpstan | no errors | no errors |
| cgl, checkRst, checkBom, lintPhp, checkTestMethodsPrefix | pass | pass |

Coverage was written before each change: the client operations
including the replacing semantics, term cleaning, the glossary and
dictionary records, all five synchronization paths, resolving a
glossary per covered pair, the console commands and the upgrade wizard.
The pre-existing regression test now proves end to end that a
translation uses the glossary published through the API v3.

## Notes for reviewers

- The rst integrity check was disabled because every documentation file
  failed it, so it is fixed and enabled again. The check came from the
  TYPO3 core unchanged and demanded a Forge issue number in each
  changelog headline plus a `See :issue:` reference. This extension
  documents by topic, so both checks were dropped rather than adding
  numbers that do not exist.
- `getLanguagesForResource()` of deepl-php 1.19 would replace the
  deprecated `/v2/glossary-language-pairs`, but the pinned DeepL mock
  server answers `/v3/languages` with 404, which would leave the path
  untestable. A `@todo` on the client interface records the condition.
- The rule skipping any pair whose target is the site default is
  unchanged from the API v2 behaviour, so no `de => en` dictionary is
  created. Worth deciding separately.
- `source_lang` and `target_lang` stay on the glossary table until the
  wizard has run and are removed with the next major version.

