### PR TITLE
[TASK] Run CI containers with docker

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -1,5 +1,15 @@
 name: tests core 12
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
   workflow_dispatch:
@@ -17,28 +27,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v12"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl -n"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
 
       - name: "Ensure UTF-8 files do not contain BOM"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkBom"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkBom"
 
       - name: "Test .rst files for integrity"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkRst"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkRst"
 
       - name: "Find duplicate exception codes"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
       - name: "Run PHPStan"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s phpstan"
 
   testsuite:
     name: all tests with core v12
@@ -53,28 +63,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v12"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Unit"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s unit"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s unit"
 
       - name: "Functional SQLite"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d sqlite"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -1,5 +1,15 @@
 name: tests core 13
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
   workflow_dispatch:
@@ -17,28 +27,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s cgl -n"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
 
       - name: "Ensure UTF-8 files do not contain BOM"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkBom"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkBom"
 
       - name: "Test .rst files for integrity"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkRst"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkRst"
 
       - name: "Find duplicate exception codes"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
       - name: "Run PHPStan"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s phpstan"
 
   testsuite:
     name: all tests with core v13
@@ -53,28 +63,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Unit"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s unit"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s unit"
 
       - name: "Functional SQLite"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -10,10 +10,13 @@ fi
 waitFor() {
     local HOST=${1}
     local PORT=${2}
+    # 60 rather than 10 seconds: mysql:8.0 needs 12-13s under docker to
+    # initialise a fresh data directory, about twice as long as under podman,
+    # so an 11 second budget aborted the functional mysql suites at random.
     local TESTCOMMAND="
         COUNT=0;
         while ! nc -z ${HOST} ${PORT}; do
-            if [ \"\${COUNT}\" -gt 10 ]; then
+            if [ \"\${COUNT}\" -gt 60 ]; then
               echo \"Can not connect to ${HOST} port ${PORT}. Aborting.\";
               exit 1;
             fi;
@@ -23,7 +26,11 @@ waitFor() {
     "
     ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} /bin/sh -c "${TESTCOMMAND}"
     if [[ $? -gt 0 ]]; then
-        kill -SIGINT -$$
+        # Not "kill -SIGINT -$$": the SIGINT trap is only installed when CI is
+        # not "true", so in CI the signal was a no-op, the run continued and the
+        # test suite connected to a database that was not listening.
+        cleanUp
+        exit 1
     fi
 }
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -552,7 +552,13 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
+                # "mode=1777" is required for docker and harmless for podman: docker runs
+                # the container as "--user $HOST_UID" with group 0, while the tmpfs comes
+                # up owned by root with mode 0755, so the test databases cannot be created
+                # and every test fails with "unable to open database file". Rootless podman
+                # passes no "--user" (it is root inside its user namespace), which is why
+                # this only shows with docker.
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -514,14 +514,21 @@ case ${TEST_SUITE} in
     composer)
         cleanCacheFiles
         COMMAND=(composer "$@")
-        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_POLICY_ADVISORIES_BLOCK=false -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
     composerUpdate)
         cleanCacheFiles
         # backup current composer.json
         cp -Rf composer.json composer.json.orig
-        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-update-${CORE_VERSION}-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} composer require --dev "typo3/minimal":"^${CORE_VERSION}"
+        # Composer 2.10 blocks advisory-affected versions from the resolver pool
+        # by default. TYPO3 v12.4 is ELTS-only, so every public 12.4.x release is
+        # permanently advisory-affected and would drop out entirely -- leaving
+        # only 13.4.31+, which need PHP 8.2, and a misleading "your php version
+        # does not satisfy that requirement" error on the v12 jobs. Testing v12
+        # support requires installing those releases. Kept in the harness on
+        # purpose: composer.json would disable the check for consumers too.
+        ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-update-${CORE_VERSION}-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_POLICY_ADVISORIES_BLOCK=false -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} composer require --dev "typo3/minimal":"^${CORE_VERSION}"
         SUITE_EXIT_CODE=$?
         # restore composer json
         cp -Rf composer.json.orig composer.json


### PR DESCRIPTION
## Why

GitHub hosted runners ship both podman and docker. Since 2026-07-29 their
podman/crun combination intermittently aborts the **first container start of a
job** with

```
Error: OCI runtime error: crun: unknown version specified
```

exit code 126. It is independent of the job, the core version and the PHP
version, and a rerun on another host clears it. Neither the runner image nor
the TYPO3 testing image changed, so this is variance in the GitHub host fleet,
not in anything of ours.

## The change

`Build/Scripts/runTests.sh` prefers podman whenever it is present and only
falls back to docker. That default is correct for the script — podman-only
machines are exactly what it is built for — so it stays. The GitHub hosted
runners are the single place these workflows meet the broken combination, so
the override belongs in the workflows.

Every `runTests.sh` call now passes `-b docker`, with the reasoning in the
workflow header so the flag can be dropped knowingly once GitHub stops
producing the mismatch.

## Selecting docker exposed a second, unrelated defect

docker runs the container as `--user $HOST_UID` with group 0, while the sqlite
tmpfs comes up owned by `root:root` with mode `0755` — so no test database can
be created and every functional sqlite test fails with `unable to open database
file`. Rootless podman is root inside its user namespace and passes no
`--user`, which is why this never showed before.

Fixed in `runTests.sh` by mounting that tmpfs with `mode=1777`: docker needs
it, podman does not mind, and it stays correct regardless of which runtime is
selected.

## This pull request is its own proof

The pipeline below runs with both changes.
