### PR TITLE
[TASK] DPL-208: Pin the database versions in CI

### DIFF
--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -78,16 +78,16 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli -i 10.5"
 
       - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql -i 10.5"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -i 8.0"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql -i 8.0"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres -i 10"

--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -78,16 +78,16 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli -i 10.5"
 
       - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql -i 10.5"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -i 8.0"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql -i 8.0"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d postgres -i 10"


### PR DESCRIPTION
Tracked as DPL-208. One commit per branch, `.github/workflows/*` only —
`Build/Scripts/runTests.sh` is untouched.

This repository was **missed during the portfolio-wide sweep on 2026-07-31**: it was
skipped for implementation because DPL-198 was already closed, and skipped for a new
label issue because DPL-208 already existed, so it fell between the two rules. It is
the last repository whose database step labels do not match what they run.

### What changes

The `Functional MariaDB 10.5 …` steps passed no `-i` and therefore ran the harness
default, **10.4**. They now pass `-i 10.5`, so they start testing the version they
have always claimed. Verified by resolving the workflow's own arguments through a
stub container binary:

```
before:  -s functional -d mariadb -a pdo_mysql            -> docker.io/mariadb:10.4
after:   -s functional -d mariadb -a pdo_mysql -i 10.5    -> docker.io/mariadb:10.5
```

**This is a real coverage change**, unlike the equivalent change on
`deepltranslate-core` (DPL-215), where the labels already named the default. Here the
jobs move from 10.4 to 10.5.

The `Functional MySQL 8.0 …` and `Functional PostgresSQL 10` steps already hit the
default their label names, so pinning them changes nothing today; it states the
intent, so a later change to `handleDbmsOptions` cannot silently move what these jobs
cover. The SQLite steps get nothing — `handleDbmsOptions` rejects `-i` for
`-d sqlite`.

10 steps per branch: 4 MariaDB, 4 MySQL, 2 PostgreSQL.

### Verification

Static plus CI, which is the stronger evidence here because it actually starts the
pinned containers.

* every workflow parses; the diff touches `.github/workflows/*` only
* structural comparison against the base: all jobs, steps, matrix entries and
  triggers identical, only the intended `run` strings differ
* every labelled step re-derived from the parsed YAML — label version equals the `-i`
  value, and every value is inside this branch's own `handleDbmsOptions` allowed list
* no `-d sqlite` step carries `-i`
