### PR TITLE
[WIP][BUGFIX] Glossary load fails with site configuration missing

### DIFF
--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -476,11 +476,19 @@ final class GlossaryRepository
             return [];
         }
 
-        $rootPage = $this->findRootPageId($pageId);
+        try {
+            $rootPage = $this->findRootPageId($pageId);
+        } catch (SiteNotFoundException) {
+            return [];
+        }
 
         $ids = [];
         foreach ($rows as $row) {
-            $glossaryRootPageID = $this->findRootPageId($row['uid']);
+            try {
+                $glossaryRootPageID = $this->findRootPageId($row['uid']);
+            } catch (SiteNotFoundException) {
+                continue;
+            }
             if ($glossaryRootPageID !== $rootPage) {
                 continue;
             }
@@ -490,6 +498,9 @@ final class GlossaryRepository
         return $ids;
     }
 
+    /**
+     * @throws SiteNotFoundException
+     */
     private function findRootPageId(int $pageId): int
     {
         $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId);


### PR DESCRIPTION
When a page has no site configuration, the glossary hard fails instead of ignoring the current glossary. Thi is an issue for editors working in a page tree not related to the failing glossary, as they do not see, what the exception is caused by.

The repository must add a try/catch, ensuring the failure is correctly handled to resolve the needed glossary correct, if a site configuration is there.